### PR TITLE
Properly handle null albumArtURI in Sonos.prototype.currentTrack

### DIFF
--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -125,8 +125,9 @@ Sonos.prototype.request = function(endpoint, action, body, responseTag, callback
         track = _this.parseDIDL(data);
         track.position = position;
         track.duration = duration;
-        track.albumArtURL = (track.albumArtURI.indexOf('http') !== -1) ? track.albumArtURI
-                            : (!!track.albumArtURI) ? 'http://' + _this.host + ':' + _this.port + track.albumArtURI : null;
+        track.albumArtURL = !track.albumArtURI ? null
+                            : (track.albumArtURI.indexOf('http') !== -1) ? track.albumArtURI
+                            : 'http://' + _this.host + ':' + _this.port + track.albumArtURI;
 
         return callback(null, track);
       });


### PR DESCRIPTION
Fixes a crash triggered by calling `currentTrack` if the track has no album art. It would try to call `indexOf` on `null` and fail.
