### PR TITLE
Fix SetPlayMode command

### DIFF
--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -493,7 +493,7 @@ Sonos.prototype.setPlayMode = function(playmode, callback) {
   var mode = { NORMAL: true, REPEAT_ALL: true, SHUFFLE: true, SHUFFLE_NOREPEAT: true }[playmode.toUpperCase()];
   if (!mode) return callback (new Error('invalid play mode ' + playmode));
   var action = '"urn:schemas-upnp-org:service:AVTransport:1#SetPlayMode"';
-  var body = '<u:SetPlayMode xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><DesiredPlayMode>' + mode + '</DesiredPlayMode></u:SetPlayMode>';
+  var body = '<u:SetPlayMode xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><NewPlayMode>' + playmode.toUpperCase() + '</NewPlayMode></u:SetPlayMode>';
   this.request(TRANSPORT_ENDPOINT, action, body, 'u:SetPlayModeResponse', function(err, data) {
     return callback(err, data);
   });


### PR DESCRIPTION
The SetPlayMode command wasn't sending the proper command to the Sonos.

There was some [discussion a while back about it not working properly](https://github.com/TheThingSystem/node-sonos/commit/0b4d1f91f8636ec8f0021163e5b1a154423be7bb#commitcomment-3180891). This change fixes it.
