### PR TITLE
Added support for checking Sonos model in search()

### DIFF
--- a/examples/search.js
+++ b/examples/search.js
@@ -2,6 +2,6 @@
 var Sonos = require('../');
 var search = Sonos.search();
 
-search.on('DeviceAvailable', function(device) {
-  console.log(device);
+search.on('DeviceAvailable', function(device, model) {
+  console.log(device, model);
 });

--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -570,8 +570,13 @@ var Search = function Search() {
   'ST: urn:schemas-upnp-org:device:ZonePlayer:1'].join('\r\n'));
 
   this.socket = dgram.createSocket('udp4', function(buffer, rinfo) {
-    if(buffer.toString().match(/.+Sonos.+/)) {
-      _this.emit('DeviceAvailable', new Sonos(rinfo.address));
+    buffer = buffer.toString();
+
+    if(buffer.match(/.+Sonos.+/)) {
+      var modelCheck = buffer.match(/SERVER.*\((.*)\)/);
+      var model = (modelCheck.length > 1 ? modelCheck[1] : null);
+
+      _this.emit('DeviceAvailable', new Sonos(rinfo.address), model);
     }
   });
 


### PR DESCRIPTION
Checks the `SERVER` header for device type and adds to the `DeviceAvailable` event.

(Also see: https://github.com/SoCo/SoCo/pull/38, in SoCo, the python equivalent Sonos library)

Solves issue bencevans/node-sonos/issues/29
