### PR TITLE
removed accidental "$" attribute in json from getZoneAttrs() and getZoneInfo()

### DIFF
--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -425,7 +425,7 @@ Sonos.prototype.getZoneInfo = function(callback) {
     if (err) return callback(err, data);
 
     var output = {};
-    for (var d in data[0]) if (data[0].hasOwnProperty(d)) output[d] = data[0][d][0];
+    for (var d in data[0]) if (data[0].hasOwnProperty(d) && d !== '$') output[d] = data[0][d][0];
     callback(null, output);
   });
 };
@@ -443,7 +443,7 @@ Sonos.prototype.getZoneAttrs = function(callback) {
     if (err) return callback(err, data);
 
     var output = {};
-    for (var d in data[0]) if (data[0].hasOwnProperty(d)) output[d] = data[0][d][0];
+    for (var d in data[0]) if (data[0].hasOwnProperty(d) && d !== '$') output[d] = data[0][d][0];
     callback(null, output);
   });
 };


### PR DESCRIPTION
Before:

```
{ '$': undefined,
  CurrentZoneName: 'Playroom',
  CurrentIcon: 'x-rincon-roomicon:playroom',
  CurrentConfiguration: '1' }
```

After:

```
{ CurrentZoneName: 'Playroom',
  CurrentIcon: 'x-rincon-roomicon:playroom',
  CurrentConfiguration: '1' }
```
