### PR TITLE
Fixed issue where getTopology() throws exception on bridge devices

### DIFF
--- a/examples/searchinfo.js
+++ b/examples/searchinfo.js
@@ -1,0 +1,23 @@
+var sonos = require('../index');
+
+console.log('\nSearching for Sonos devices on network...');
+
+sonos.search(function(device, model) {
+	var devInfo = '\n';
+	devInfo += 'Device \t' + JSON.stringify(device) + ' (' + model + ')\n';
+	device.getZoneAttrs(function(err, attrs) {
+		if (err) devInfo += '`- failed to retrieve zone attributes\n';
+		devInfo += '`- attrs: \t' + JSON.stringify(attrs).replace(/",/g, '",\n\t\t') + '\n';
+
+		device.getZoneInfo(function(err, info) {
+			if (err) devInfo += '`- failed to retrieve zone information\n';
+			
+			devInfo += '`- info: \t' + JSON.stringify(info).replace(/",/g, '",\n\t\t') + '\n';
+
+			device.getTopology(function(err, info) {
+				devInfo += '`- topology: \t' + JSON.stringify(info.zones).replace(/",/g, '",\n\t\t') + '\n';
+				console.log(devInfo);
+			});
+		});
+	});
+});

--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -628,12 +628,21 @@ Sonos.prototype.getTopology = function(callback) {
     debug(body);
     xml2js.parseString(body, function(err, topology) {
       if(err) return callback(err);
-      var zones = _.map(topology.ZPSupportInfo.ZonePlayers[0].ZonePlayer, function(zone) {
-        return _.extend(zone.$, {name: zone._});
-      });
-      var mediaServers = _.map(topology.ZPSupportInfo.MediaServers[0].MediaServer, function(zone) {
-        return _.extend(zone.$, {name: zone._});
-      });
+      var info = topology.ZPSupportInfo;
+      var zones = null, mediaServers = null;
+
+      if (info.ZonePlayers && info.ZonePlayers.length > 0) {
+        zones = _.map(info.ZonePlayers[0].ZonePlayer, function(zone) {
+          return _.extend(zone.$, {name: zone._});
+        });
+      }
+
+      if (info.MediaServers && info.MediaServers.length > 0) {
+        mediaServers = _.map(info.MediaServers[0].MediaServer, function(zone) {
+          return _.extend(zone.$, {name: zone._});
+        });
+      }
+
       callback(null, {
         zones: zones,
         mediaServers: mediaServers


### PR DESCRIPTION
On Bridge devices, the returned info doesn't include the MediaServers property, which the library expects. Added checks to avoid this.
