### PR TITLE
queueSpotify() Implementation

### DIFF
--- a/examples/playspotify.js
+++ b/examples/playspotify.js
@@ -2,6 +2,6 @@ var Sonos = require('../').Sonos;
 
 var sonos = new Sonos(process.env.SONOS_HOST || '192.168.2.19', process.env.SONOS_PORT || 1400);
 
-sonos.queueSpotify('6EKQbI0jKua5AehBsicMdD', function(err, data) {
+sonos.queueSpotify('6ouTGbETM7ZdID1eMXZJde', function(err, data) {
 	console.log(err, data);
 });

--- a/examples/playspotify.js
+++ b/examples/playspotify.js
@@ -1,0 +1,7 @@
+var Sonos = require('../').Sonos;
+
+var sonos = new Sonos(process.env.SONOS_HOST || '192.168.2.19', process.env.SONOS_PORT || 1400);
+
+sonos.queueSpotify('6EKQbI0jKua5AehBsicMdD', function(err, data) {
+	console.log(err, data);
+});

--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -643,6 +643,40 @@ Sonos.prototype.getTopology = function(callback) {
 };
 
 /**
+ * Spotify queueSpotify
+ * @param  {Function} callback (err, queued)
+ */
+Sonos.prototype.queueSpotify = function(spotify_id, callback) {
+  debug('Sonos.queueSpotify(%j)', callback);
+  
+  var rand = Math.floor(Math.random() * 10000000) + 99999999
+  var next = 1;
+  var meta = '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">\
+    <item id="' + rand + 'spotify%3atrack%3a' + spotify_id + '" restricted="true">\
+    <dc:title></dc:title>\
+    <upnp:class>object.item.audioItem.musicTrack</upnp:class>\
+    <desc id="cdudn" nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">SA_RINCON2311_X_#Svc2311-0-Token</desc>\
+    </item>\
+    </DIDL-Lite>';
+
+
+  var htmlEntities = function (str) {
+    return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  }
+
+  var action = '"urn:schemas-upnp-org:service:AVTransport:1#AddURIToQueue"';
+  var body = '<u:AddURIToQueue xmlns:u="urn:schemas-upnp-org:service:AVTransport:1">\
+    <InstanceID>0</InstanceID>\
+    <EnqueuedURI>x-sonos-spotify:spotify%3atrack%3a' + spotify_id + '?sid=12&amp;flags=32</EnqueuedURI>\
+    <EnqueuedURIMetaData>' + htmlEntities(meta) + '</EnqueuedURIMetaData>\
+    <DesiredFirstTrackNumberEnqueued>0</DesiredFirstTrackNumberEnqueued>\
+    <EnqueueAsNext>' + next + '</EnqueueAsNext>\
+    </u:AddURIToQueue>';
+
+  return this.request(TRANSPORT_ENDPOINT, action, body, 'u:AddURIToQueueResponse', callback);
+};
+
+/**
  * Search "Class"
  * Emits 'DeviceAvailable' on a Sonos Component Discovery
  */

--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -649,13 +649,13 @@ Sonos.prototype.getTopology = function(callback) {
 Sonos.prototype.queueSpotify = function(spotify_id, callback) {
   debug('Sonos.queueSpotify(%j)', callback);
   
-  var rand = Math.floor(Math.random() * 10000000) + 99999999
+  var random = 10100000 || Math.floor(Math.random() * 10000000) + 99999999
   var next = 1;
   var meta = '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">\
-    <item id="' + rand + 'spotify%3atrack%3a' + spotify_id + '" restricted="true">\
+    <item id="' + 10100000 + 'spotify%3atrack%3a' + spotify_id + '" restricted="true">\
     <dc:title></dc:title>\
     <upnp:class>object.item.audioItem.musicTrack</upnp:class>\
-    <desc id="cdudn" nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">SA_RINCON2311_X_#Svc2311-0-Token</desc>\
+    <desc id="cdudn" nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">SA_RINCON3079_X_#Svc3079-0-Token</desc>\
     </item>\
     </DIDL-Lite>';
 
@@ -667,7 +667,7 @@ Sonos.prototype.queueSpotify = function(spotify_id, callback) {
   var action = '"urn:schemas-upnp-org:service:AVTransport:1#AddURIToQueue"';
   var body = '<u:AddURIToQueue xmlns:u="urn:schemas-upnp-org:service:AVTransport:1">\
     <InstanceID>0</InstanceID>\
-    <EnqueuedURI>x-sonos-spotify:spotify%3atrack%3a' + spotify_id + '?sid=12&amp;flags=32</EnqueuedURI>\
+    <EnqueuedURI>x-sonos-spotify:spotify%3atrack%3a' + spotify_id + '</EnqueuedURI>\
     <EnqueuedURIMetaData>' + htmlEntities(meta) + '</EnqueuedURIMetaData>\
     <DesiredFirstTrackNumberEnqueued>0</DesiredFirstTrackNumberEnqueued>\
     <EnqueueAsNext>' + next + '</EnqueueAsNext>\


### PR DESCRIPTION
(Work in progress)

This needs to be tested by multiple parties before merging.. pulled in code from issue #24 and made some modifications.

In particular, I'm not sure where that "random" number comes from - on my system, it uses the same number (```10030020```) every time.

Todo:
- [ ] Output needs to be sanitized
- [ ] Linting problems
- [ ] Generalize for ```queueNext()```

Sample output:
```
$ SONOS_HOST=172.17.105.103 node examples/playspotify.js
null [ { '$': { 'xmlns:u': 'urn:schemas-upnp-org:service:AVTransport:1' },
    FirstTrackNumberEnqueued: [ '45' ],
    NumTracksAdded: [ '1' ],
    NewQueueLength: [ '45' ] } ]
```