### PR TITLE
Cleaned up Travis/Gruntfile for Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,5 @@
 language: node_js
-services:
-  - redis-server
-env:
-  - TEST_CMD="lint"
 node_js:
   - "0.10"
 before_script:
   - npm install -g grunt-cli
-script:
-  - grunt lint

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -39,11 +39,7 @@ module.exports = function(grunt) {
   grunt.registerTask('lint', ['jshint']);
   grunt.registerTask('test', 'mochaTest');
 
-  if(process.env.TEST_CMD) {
-    grunt.registerTask('travis', process.env.TEST_CMD);
-  }
-
   // By default, lint and run all tests.
-  grunt.registerTask('default', ['jshint', 'mochaTest']);
+  grunt.registerTask('default', ['jshint', 'test']);
 
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Node.js Sonos Interface",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "grunt"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Looks like I forgot to change the travis config to actually run the test - fixed so that it runs both the linter and mocha tests.

Also removed the `redis-server` service from travis file (doesn't seem to be required?)
