### PR TITLE
add support for generic UPnP audio

### DIFF
--- a/lib/events/listener.js
+++ b/lib/events/listener.js
@@ -33,6 +33,8 @@ Listener.prototype._startInternalServer = function(callback) {
     this.port = port;
     callback(null, port);
 
+    setInterval(this._renewServices.bind(this), 1 * 1000);
+
   }.bind(this));
 
 };
@@ -61,6 +63,47 @@ Listener.prototype._messageHandler = function(req, res) {
   }
 };
 
+Listener.prototype._renewServices = function() {
+  var sid;
+
+  var now = new Date().getTime();
+
+  var renew = function(sid) {
+    return function(err, response) {
+      var serviceEndpoint = this.services[sid].endpoint;
+
+      if (err || ((response.statusCode !== 200) && (response.statusCode !== 412))) {
+        this.emit('error', err || response.statusMessage, serviceEndpoint, sid);
+      } else if (response.statusCode === 412) { // restarted, this is why renewal is at most 300sec
+        delete this.services[sid];
+        this.addService(serviceEndpoint, function(err, sid) {
+          if (!!err) this.emit('error', err, serviceEndpoint, sid);
+        });
+      } else {
+        this.services[sid].renew = this.renew_at(response.headers.timeout);
+      }
+    };
+  };
+
+  for (sid in this.services) {
+    var thisService = this.services[sid];
+
+    if (now < thisService.renew) continue;
+
+    var opt = {
+      url: 'http://' + this.device.host + ':' + this.device.port + thisService.endpoint,
+      method: 'SUBSCRIBE',
+      headers: {
+        SID: sid,
+        Timeout: 'Second-3600'
+      }
+    };
+
+    request(opt, renew(sid).bind(this));
+
+  }
+};
+
 Listener.prototype.addService = function(serviceEndpoint, callback) {
   if (!this.server) {
     throw 'Service endpoints can only be added after listen() is called';
@@ -78,16 +121,13 @@ Listener.prototype.addService = function(serviceEndpoint, callback) {
 
     request(opt, function(err, response) {
       if (err || response.statusCode !== 200) {
-        console.log(err || response.message || response.statusCode);
+        if (!callback) return console.log(err || response.message || response.statusCode);
         callback(err || response.statusMessage);
       } else {
-        var timeout = response.headers.timeout, value;
-        
-        if ((!!timeout) && (timeout.indexOf('Second-') === 0)) timeout = timeout.substr(7);
-        if ((!!timeout) && (!isNaN(timeout))) value = parseInt(timeout, 10) * 1000;
-        callback(null, response.headers.sid, value);
+        callback(null, response.headers.sid);
 
         this.services[response.headers.sid] = {
+          renew: this.renew_at(response.headers.timeout),
           endpoint: serviceEndpoint,
           data: {}
         };
@@ -95,6 +135,16 @@ Listener.prototype.addService = function(serviceEndpoint, callback) {
     }.bind(this));
 
   }
+};
+
+Listener.prototype.renew_at = function(timeout) {
+  var seconds;
+
+  if ((!!timeout) && (timeout.indexOf('Second-') === 0)) timeout = timeout.substr(7);
+  seconds = (((!!timeout) && (!isNaN(timeout))) ? parseInt(timeout, 10) : 3600) - 15;
+  if (seconds < 0) seconds = 15; else if (seconds > 300) seconds = 300;
+
+  return (new Date().getTime() + (seconds * 1000));
 };
 
 Listener.prototype.listen = function(callback) {

--- a/lib/events/listener.js
+++ b/lib/events/listener.js
@@ -78,7 +78,7 @@ Listener.prototype.addService = function(serviceEndpoint, callback) {
 
     request(opt, function(err, response) {
       if (err || response.statusCode !== 200) {
-        console.log(response.message || response.statusCode);
+        console.log(err || response.message || response.statusCode);
         callback(err || response.statusMessage);
       } else {
         callback(null, response.headers.sid);

--- a/lib/events/listener.js
+++ b/lib/events/listener.js
@@ -81,7 +81,11 @@ Listener.prototype.addService = function(serviceEndpoint, callback) {
         console.log(err || response.message || response.statusCode);
         callback(err || response.statusMessage);
       } else {
-        callback(null, response.headers.sid);
+        var timeout = response.headers.timeout, value;
+        
+        if ((!!timeout) && (timeout.indexOf('Second-') === 0)) timeout = timeout.substr(7);
+        if ((!!timeout) && (!isNaN(timeout))) value = parseInt(timeout, 10) * 1000;
+        callback(null, response.headers.sid, value);
 
         this.services[response.headers.sid] = {
           endpoint: serviceEndpoint,

--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -740,7 +740,7 @@ var Search = function Search() {
   var _this = this;
 
   var PLAYER_SEARCH = new Buffer(['M-SEARCH * HTTP/1.1',
-  'HOST: 239.255.255.250:reservedSSDPport',
+  'HOST: 239.255.255.250:1900',
   'MAN: ssdp:discover',
   'MX: 1',
   'ST: urn:schemas-upnp-org:device:ZonePlayer:1'].join('\r\n'));

--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -61,9 +61,14 @@ var htmlEntities = function (str) {
  * @param {String} host IP/DNS
  * @param {Number} port
  */
-var Sonos = function Sonos(host, port) {
+var Sonos = function Sonos(host, port, options) {
   this.host = host;
   this.port = port || 1400;
+  this.options = options || {};
+  if (!this.options.endpoints) this.options.endpoints = {};
+  if (!this.options.endpoints.transport) this.options.endpoints.transport = TRANSPORT_ENDPOINT;
+  if (!this.options.endpoints.rendering) this.options.endpoints.rendering = RENDERING_ENDPOINT;
+  if (!this.options.endpoints.device)    this.options.endpoints.device    = DEVICE_ENDPOINT;
 };
 
 /**
@@ -90,6 +95,10 @@ Sonos.prototype.request = function(endpoint, action, body, responseTag, callback
 
     (new xml2js.Parser()).parseString(body, function(err, json) {
       if (err) return callback(err);
+
+      if ((!json) || (!json['s:Envelope']) || (!util.isArray(json['s:Envelope']['s:Body']))) {
+        return callback(new Error('Invalid response for ' + action + ': ' + JSON.stringify(json)));
+      }
 
       if(typeof json['s:Envelope']['s:Body'][0]['s:Fault'] !== 'undefined')
         return callback(json['s:Envelope']['s:Body'][0]['s:Fault']);
@@ -179,7 +188,7 @@ Sonos.prototype.currentTrack = function(callback) {
   var body = '<u:GetPositionInfo xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><Channel>Master</Channel></u:GetPositionInfo>';
   var responseTag = 'u:GetPositionInfoResponse';
 
-  return this.request(TRANSPORT_ENDPOINT, action, body, responseTag, function(err, data) {
+  return this.request(this.options.endpoints.transport, action, body, responseTag, function(err, data) {
     if (err) return callback(err);
 
     if ((!util.isArray(data)) || (data.length < 1)) return {};
@@ -192,7 +201,7 @@ Sonos.prototype.currentTrack = function(callback) {
                    (parseInt(data[0].TrackDuration[0].split(':')[1], 10) * 60) +
                    parseInt(data[0].TrackDuration[0].split(':')[2], 10);
 
-    if (metadata) {
+    if ((metadata) && (metadata[0].length > 0)) {
       return (new xml2js.Parser()).parseString(metadata, function(err, data) {
         var track;
 
@@ -208,7 +217,10 @@ Sonos.prototype.currentTrack = function(callback) {
         return callback(null, track);
       });
     } else {
-      return callback(null, { position: position, duration: duration });
+      var track = { position: position, duration: duration };
+
+      if (!!data[0].TrackURI) track.uri = data[0].TrackURI[0];
+      return callback(null, track);
     }
   });
 };
@@ -242,7 +254,7 @@ Sonos.prototype.getVolume = function(callback) {
   var body = '<u:GetVolume xmlns:u="urn:schemas-upnp-org:service:RenderingControl:1"><InstanceID>0</InstanceID><Channel>Master</Channel></u:GetVolume>';
   var responseTag = 'u:GetVolumeResponse';
 
-  return this.request(RENDERING_ENDPOINT, action, body, responseTag, function(err, data) {
+  return this.request(this.options.endpoints.rendering, action, body, responseTag, function(err, data) {
     if (err) return callback(err);
 
     callback(null, parseInt(data[0].CurrentVolume[0], 10));
@@ -260,7 +272,7 @@ Sonos.prototype.getMuted = function(callback) {
   var body = '<u:GetMute xmlns:u="urn:schemas-upnp-org:service:RenderingControl:1"><InstanceID>0</InstanceID><Channel>Master</Channel></u:GetMute>';
   var responseTag = 'u:GetMuteResponse';
 
-  return this.request(RENDERING_ENDPOINT, action, body, responseTag, function(err, data) {
+  return this.request(this.options.endpoints.rendering, action, body, responseTag, function(err, data) {
     if (err) return callback(err);
 
     callback(null, parseInt(data[0].CurrentMute[0], 10) ? true : false);
@@ -300,7 +312,7 @@ Sonos.prototype.play = function(uri, callback) {
 
     action = '"urn:schemas-upnp-org:service:AVTransport:1#Play"';
     body = '<u:Play xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><Speed>1</Speed></u:Play>';
-    return this.request(TRANSPORT_ENDPOINT, action, body, 'u:PlayResponse', function(err, data) {
+    return this.request(this.options.endpoints.transport, action, body, 'u:PlayResponse', function(err, data) {
       if (err) return cb(err);
 
       if (data[0].$['xmlns:u'] === 'urn:schemas-upnp-org:service:AVTransport:1') {
@@ -324,7 +336,7 @@ Sonos.prototype.stop = function(callback) {
   var action, body;
   action = '"urn:schemas-upnp-org:service:AVTransport:1#Stop"';
   body = '<u:Stop xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><Speed>1</Speed></u:Stop>';
-  return this.request(TRANSPORT_ENDPOINT, action, body, 'u:StopResponse', function(err, data) {
+  return this.request(this.options.endpoints.transport, action, body, 'u:StopResponse', function(err, data) {
     if (err) return callback(err);
 
     if (data[0].$['xmlns:u'] === 'urn:schemas-upnp-org:service:AVTransport:1') {
@@ -347,7 +359,7 @@ Sonos.prototype.pause = function(callback) {
   var action, body;
   action = '"urn:schemas-upnp-org:service:AVTransport:1#Pause"';
   body = '<u:Pause xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><Speed>1</Speed></u:Pause>';
-  return this.request(TRANSPORT_ENDPOINT, action, body, 'u:PauseResponse', function(err, data) {
+  return this.request(this.options.endpoints.transport, action, body, 'u:PauseResponse', function(err, data) {
     if (err) return callback(err);
 
     if (data[0].$['xmlns:u'] === 'urn:schemas-upnp-org:service:AVTransport:1') {
@@ -379,7 +391,7 @@ Sonos.prototype.seek = function(seconds, callback) {
 
   action = '"urn:schemas-upnp-org:service:AVTransport:1#Seek"';
   body = '<u:Seek xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><Unit>REL_TIME</Unit><Target>' + hh + ':' + mm + ':' + ss + '</Target></u:Seek>';
-  return this.request(TRANSPORT_ENDPOINT, action, body, 'u:SeekResponse', function(err, data) {
+  return this.request(this.options.endpoints.transport, action, body, 'u:SeekResponse', function(err, data) {
     if (err) return callback(err);
 
     if (data[0].$['xmlns:u'] === 'urn:schemas-upnp-org:service:AVTransport:1') {
@@ -402,7 +414,7 @@ Sonos.prototype.next = function(callback) {
   var action, body;
   action = '"urn:schemas-upnp-org:service:AVTransport:1#Next"';
   body = '<u:Next xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><Speed>1</Speed></u:Next>';
-  this.request(TRANSPORT_ENDPOINT, action, body, 'u:NextResponse', function(err, data) {
+  this.request(this.options.endpoints.transport, action, body, 'u:NextResponse', function(err, data) {
     if (err) {
       return callback(err);
     }
@@ -426,7 +438,7 @@ Sonos.prototype.previous = function(callback) {
   var action, body;
   action = '"urn:schemas-upnp-org:service:AVTransport:1#Previous"';
   body = '<u:Previous xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><Speed>1</Speed></u:Previous>';
-  this.request(TRANSPORT_ENDPOINT, action, body, 'u:PreviousResponse', function(err, data) {
+  this.request(this.options.endpoints.transport, action, body, 'u:PreviousResponse', function(err, data) {
     if (err) {
       return callback(err);
     }
@@ -460,7 +472,7 @@ Sonos.prototype.queueNext = function(uri, callback) {
 
   var action = '"urn:schemas-upnp-org:service:AVTransport:1#SetAVTransportURI"';
   var body = '<u:SetAVTransportURI xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><CurrentURI>' + options.uri + '</CurrentURI><CurrentURIMetaData>' + options.metadata + '</CurrentURIMetaData></u:SetAVTransportURI>';
-  this.request(TRANSPORT_ENDPOINT, action, body, 'u:SetAVTransportURIResponse', function(err, data) {
+  this.request(this.options.endpoints.transport, action, body, 'u:SetAVTransportURIResponse', function(err, data) {
     if (callback) {
       return callback(err, data);
     } else {
@@ -484,7 +496,7 @@ Sonos.prototype.queue = function(uri, positionInQueue, callback) {
   }
   var action = '"urn:schemas-upnp-org:service:AVTransport:1#AddURIToQueue"';
   var body = '<u:AddURIToQueue xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><EnqueuedURI>' + uri + '</EnqueuedURI><EnqueuedURIMetaData></EnqueuedURIMetaData><DesiredFirstTrackNumberEnqueued>' + positionInQueue + '</DesiredFirstTrackNumberEnqueued><EnqueueAsNext>1</EnqueueAsNext></u:AddURIToQueue>';
-  this.request(TRANSPORT_ENDPOINT, action, body, 'u:AddURIToQueueResponse', function(err, data) {
+  this.request(this.options.endpoints.transport, action, body, 'u:AddURIToQueueResponse', function(err, data) {
     return callback(err, data);
   });
 };
@@ -498,7 +510,7 @@ Sonos.prototype.flush = function(callback) {
   var action, body;
   action = '"urn:schemas-upnp-org:service:AVTransport:1#RemoveAllTracksFromQueue"';
   body = '<u:RemoveAllTracksFromQueue xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID></u:RemoveAllTracksFromQueue>';
-  this.request(TRANSPORT_ENDPOINT, action, body, 'u:RemoveAllTracksFromQueueResponse', function(err, data) {
+  this.request(this.options.endpoints.transport, action, body, 'u:RemoveAllTracksFromQueueResponse', function(err, data) {
     return callback(err, data);
   });
 };
@@ -511,7 +523,7 @@ Sonos.prototype.getLEDState = function(callback) {
   debug('Sonos.getLEDState(%j)', callback);
   var action = '"urn:schemas-upnp-org:service:DeviceProperties:1#GetLEDState"';
   var body = '<u:GetLEDState xmlns:u="urn:schemas-upnp-org:service:DeviceProperties:1"></u:GetLEDState>';
-  this.request(DEVICE_ENDPOINT, action, body, 'u:GetLEDStateResponse', function(err, data) {
+  this.request(this.options.endpoint.device, action, body, 'u:GetLEDStateResponse', function(err, data) {
     if (err) return callback(err, data);
     if(data[0] && data[0].CurrentLEDState && data[0].CurrentLEDState[0])
       return callback(null, data[0].CurrentLEDState[0]);
@@ -528,7 +540,7 @@ Sonos.prototype.setLEDState = function(desiredState, callback) {
   debug('Sonos.setLEDState(%j, %j)', desiredState, callback);
   var action = '"urn:schemas-upnp-org:service:DeviceProperties:1#SetLEDState"';
   var body = '<u:SetLEDState xmlns:u="urn:schemas-upnp-org:service:DeviceProperties:1"><DesiredLEDState>' + desiredState + '</DesiredLEDState></u:SetLEDState>';
-  this.request(DEVICE_ENDPOINT, action, body, 'u:SetLEDStateResponse', function(err) {
+  this.request(this.options.endpoint.device, action, body, 'u:SetLEDStateResponse', function(err) {
     return callback(err);
   });
 };
@@ -541,7 +553,7 @@ Sonos.prototype.getZoneInfo = function(callback) {
   debug('Sonos.getZoneInfo(%j)', callback);
   var action = '"urn:schemas-upnp-org:service:DeviceProperties:1#GetZoneInfo"';
   var body = '<u:GetZoneInfo xmlns:u="urn:schemas-upnp-org:service:DeviceProperties:1"></u:GetZoneInfo>';
-  this.request(DEVICE_ENDPOINT, action, body, 'u:GetZoneInfoResponse', function(err, data) {
+  this.request(this.options.endpoint.device, action, body, 'u:GetZoneInfoResponse', function(err, data) {
     if (err) return callback(err, data);
 
     var output = {};
@@ -559,7 +571,7 @@ Sonos.prototype.getZoneAttrs = function(callback) {
 
   var action = '"urn:schemas-upnp-org:service:DeviceProperties:1#GetZoneAttributes"';
   var body = '"<u:GetZoneAttributes xmlns:u="urn:schemas-upnp-org:service:DeviceProperties:1"></u:SetZoneAttributes>"';
-  this.request(DEVICE_ENDPOINT, action, body, 'u:GetZoneAttributesResponse', function(err, data) {
+  this.request(this.options.endpoint.device, action, body, 'u:GetZoneAttributesResponse', function(err, data) {
     if (err) return callback(err, data);
 
     var output = {};
@@ -597,7 +609,7 @@ Sonos.prototype.setName = function(name, callback) {
   name = name.replace(/[<&]/g, function(str) { return (str === '&') ? '&amp;' : '&lt;';});
   var action = '"urn:schemas-upnp-org:service:DeviceProperties:1#SetZoneAttributes"';
   var body = '"<u:SetZoneAttributes xmlns:u="urn:schemas-upnp-org:service:DeviceProperties:1"><DesiredZoneName>' + name + '</DesiredZoneName><DesiredIcon /><DesiredConfiguration /></u:SetZoneAttributes>"';
-  this.request(DEVICE_ENDPOINT, action, body, 'u:SetZoneAttributesResponse', function(err, data) {
+  this.request(this.options.endpoint.device, action, body, 'u:SetZoneAttributesResponse', function(err, data) {
     return callback(err, data);
   });
 };
@@ -614,7 +626,7 @@ Sonos.prototype.setPlayMode = function(playmode, callback) {
   if (!mode) return callback (new Error('invalid play mode ' + playmode));
   var action = '"urn:schemas-upnp-org:service:AVTransport:1#SetPlayMode"';
   var body = '<u:SetPlayMode xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><NewPlayMode>' + playmode.toUpperCase() + '</NewPlayMode></u:SetPlayMode>';
-  this.request(TRANSPORT_ENDPOINT, action, body, 'u:SetPlayModeResponse', function(err, data) {
+  this.request(this.options.endpoints.transport, action, body, 'u:SetPlayModeResponse', function(err, data) {
     return callback(err, data);
   });
 };
@@ -629,7 +641,7 @@ Sonos.prototype.setVolume = function(volume, callback) {
   debug('Sonos.setVolume(%j, %j)', volume, callback);
   var action = '"urn:schemas-upnp-org:service:RenderingControl:1#SetVolume"';
   var body = '<u:SetVolume xmlns:u="urn:schemas-upnp-org:service:RenderingControl:1"><InstanceID>0</InstanceID><Channel>Master</Channel><DesiredVolume>' + volume + '</DesiredVolume></u:SetVolume>';
-  this.request(RENDERING_ENDPOINT, action, body, 'u:SetVolumeResponse', function(err, data) {
+  this.request(this.options.endpoints.rendering, action, body, 'u:SetVolumeResponse', function(err, data) {
     return callback(err, data);
   });
 };
@@ -645,7 +657,7 @@ Sonos.prototype.setMuted = function(muted, callback) {
   if (typeof muted === 'string') muted = parseInt(muted, 10) ? true : false;
   var action = '"urn:schemas-upnp-org:service:RenderingControl:1#SetMute"';
   var body = '<u:SetMute xmlns:u="urn:schemas-upnp-org:service:RenderingControl:1"><InstanceID>0</InstanceID><Channel>Master</Channel><DesiredMute>' + (muted ? '1' : '0') + '</DesiredMute></u:SetMute>';
-  this.request(RENDERING_ENDPOINT, action, body, 'u:SetMutedResponse', function(err, data) {
+  this.request(this.options.endpoints.rendering, action, body, 'u:SetMutedResponse', function(err, data) {
     return callback(err, data);
   });
 };
@@ -694,7 +706,7 @@ Sonos.prototype.getCurrentState = function(callback) {
   var body = '<u:GetTransportInfo xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID></u:GetTransportInfo>';
   var state = null;
 
-  return this.request(TRANSPORT_ENDPOINT, action, body, 'u:GetTransportInfoResponse', function(err, data) {
+  return this.request(this.options.endpoints.transport, action, body, 'u:GetTransportInfoResponse', function(err, data) {
     if (err) {
       callback(err);
       return;
@@ -706,6 +718,10 @@ Sonos.prototype.getCurrentState = function(callback) {
       state = 'playing';
     } else if (JSON.stringify(data[0].CurrentTransportState) === '["PAUSED_PLAYBACK"]') {
       state = 'paused';
+    } else if (JSON.stringify(data[0].CurrentTransportState) === '["TRANSITIONING"]') {
+      state = 'transitioning';
+    } else if (JSON.stringify(data[0].CurrentTransportState) === '["NO_MEDIA_PRESENT"]') {
+      state = 'no_media';
     }
     
     return callback(err, state);

--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -747,6 +747,8 @@ var Search = function Search() {
 
   this.socket = dgram.createSocket('udp4', function(buffer, rinfo) {
     buffer = buffer.toString();
+console.log(buffer)
+console.log(rinfo)
 
     if(buffer.match(/.+Sonos.+/)) {
       var modelCheck = buffer.match(/SERVER.*\((.*)\)/);

--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -523,7 +523,7 @@ Sonos.prototype.getLEDState = function(callback) {
   debug('Sonos.getLEDState(%j)', callback);
   var action = '"urn:schemas-upnp-org:service:DeviceProperties:1#GetLEDState"';
   var body = '<u:GetLEDState xmlns:u="urn:schemas-upnp-org:service:DeviceProperties:1"></u:GetLEDState>';
-  this.request(this.options.endpoint.device, action, body, 'u:GetLEDStateResponse', function(err, data) {
+  this.request(this.options.endpoints.device, action, body, 'u:GetLEDStateResponse', function(err, data) {
     if (err) return callback(err, data);
     if(data[0] && data[0].CurrentLEDState && data[0].CurrentLEDState[0])
       return callback(null, data[0].CurrentLEDState[0]);
@@ -540,7 +540,7 @@ Sonos.prototype.setLEDState = function(desiredState, callback) {
   debug('Sonos.setLEDState(%j, %j)', desiredState, callback);
   var action = '"urn:schemas-upnp-org:service:DeviceProperties:1#SetLEDState"';
   var body = '<u:SetLEDState xmlns:u="urn:schemas-upnp-org:service:DeviceProperties:1"><DesiredLEDState>' + desiredState + '</DesiredLEDState></u:SetLEDState>';
-  this.request(this.options.endpoint.device, action, body, 'u:SetLEDStateResponse', function(err) {
+  this.request(this.options.endpoints.device, action, body, 'u:SetLEDStateResponse', function(err) {
     return callback(err);
   });
 };
@@ -553,7 +553,7 @@ Sonos.prototype.getZoneInfo = function(callback) {
   debug('Sonos.getZoneInfo(%j)', callback);
   var action = '"urn:schemas-upnp-org:service:DeviceProperties:1#GetZoneInfo"';
   var body = '<u:GetZoneInfo xmlns:u="urn:schemas-upnp-org:service:DeviceProperties:1"></u:GetZoneInfo>';
-  this.request(this.options.endpoint.device, action, body, 'u:GetZoneInfoResponse', function(err, data) {
+  this.request(this.options.endpoints.device, action, body, 'u:GetZoneInfoResponse', function(err, data) {
     if (err) return callback(err, data);
 
     var output = {};
@@ -571,7 +571,7 @@ Sonos.prototype.getZoneAttrs = function(callback) {
 
   var action = '"urn:schemas-upnp-org:service:DeviceProperties:1#GetZoneAttributes"';
   var body = '"<u:GetZoneAttributes xmlns:u="urn:schemas-upnp-org:service:DeviceProperties:1"></u:SetZoneAttributes>"';
-  this.request(this.options.endpoint.device, action, body, 'u:GetZoneAttributesResponse', function(err, data) {
+  this.request(this.options.endpoints.device, action, body, 'u:GetZoneAttributesResponse', function(err, data) {
     if (err) return callback(err, data);
 
     var output = {};
@@ -609,7 +609,7 @@ Sonos.prototype.setName = function(name, callback) {
   name = name.replace(/[<&]/g, function(str) { return (str === '&') ? '&amp;' : '&lt;';});
   var action = '"urn:schemas-upnp-org:service:DeviceProperties:1#SetZoneAttributes"';
   var body = '"<u:SetZoneAttributes xmlns:u="urn:schemas-upnp-org:service:DeviceProperties:1"><DesiredZoneName>' + name + '</DesiredZoneName><DesiredIcon /><DesiredConfiguration /></u:SetZoneAttributes>"';
-  this.request(this.options.endpoint.device, action, body, 'u:SetZoneAttributesResponse', function(err, data) {
+  this.request(this.options.endpoints.device, action, body, 'u:SetZoneAttributesResponse', function(err, data) {
     return callback(err, data);
   });
 };

--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -747,8 +747,6 @@ var Search = function Search() {
 
   this.socket = dgram.createSocket('udp4', function(buffer, rinfo) {
     buffer = buffer.toString();
-console.log(buffer)
-console.log(rinfo)
 
     if(buffer.match(/.+Sonos.+/)) {
       var modelCheck = buffer.match(/SERVER.*\((.*)\)/);


### PR DESCRIPTION
hi. here are some (hopefully) very-straight forward changes to provide support for generic UPnP audio devices ... the basic hook is to add an optional third parameter to the Sonos() constructor allowing the caller to specify where the endpoints reside (overriding the hard-coded Sonos values.

enjoy!