### PR TITLE
Fix error emitter for search

### DIFF
--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -740,7 +740,7 @@ var Search = function Search() {
     }
   });
 
-  this.on('error', function(err) {
+  this.socket.on('error', function(err) {
     _this.emit('error', err);
   });
 


### PR DESCRIPTION
cc/ @bencevans 

Believe this is a typo.. meant to emit `error` on the Search object when the socket comes up with an error?
