### PR TITLE
Add queue selection

### DIFF
--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -471,6 +471,35 @@ Sonos.prototype.previous = function(callback) {
 };
 
 /**
+ * Select Queue. Mostly required after turning on the speakers otherwise play, setPlaymode and other commands will fail.
+ * @param  {Function}  callback (err, data)  Optional
+ */
+Sonos.prototype.selectQueue = function(callback) {
+  debug('Sonos.selectQueue(%j)', callback);
+  var cb = callback || function() {};
+  var self = this;
+  self.getZoneInfo(function(err, data){
+    if(!err) {
+      var action = '"urn:schemas-upnp-org:service:AVTransport:1#SetAVTransportURI"';
+      var body = '<u:SetAVTransportURI xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><CurrentURI>' + 'x-rincon-queue:RINCON_' + data.MACAddress.replace(/:/g, '') + '0' + self.port + '#0</CurrentURI><CurrentURIMetaData></CurrentURIMetaData></u:SetAVTransportURI>';
+      self.request(self.options.endpoints.transport, action, body, 'u:SetAVTransportURIResponse', function(err, data) {
+        if (err) return cb(err);
+        if (data[0].$['xmlns:u'] === 'urn:schemas-upnp-org:service:AVTransport:1') {
+          return cb(null, true);
+        } else {
+          return cb(new Error({
+            err: err,
+            data: data
+          }), false);
+        }
+      });
+    } else {
+      return cb(err);
+    }
+  });
+};
+
+/**
  * Queue a Song Next
  * @param  {String|Object}   uri      URI to Audio Stream or Object containing options (uri, metadata)
  * @param  {Function} callback (err, queued)


### PR DESCRIPTION
No one seems to have missed it, but I need it at least once a day :-)

I regulary turn off my speakers to save energy (going to sleep, going to work). 10-15 Watts on standby for  my 2x Play:1 and 1x Sub is a little wasteful. And I want even more devices in the future.

I'm using a HomeMatic Button or a ioBroker alarm clock script to turn them on manually or on wakeup.
On wakeup I automatically fill the queue with my morning playlist, set shuffle mode and start playing using node-sonos.

The problem is, the queue ist not selected after power on. Even when I fill it with tracks, commands like play and setPlayMode will fail.

You can test it by yourself. Turn on your speakers, start any Sonos App and try to activate Shuffle, Repeat or Fading. They are grayed out.

Start `sonos.selectQueue();` and the buttons will be available even no title has been added to the queue yet.