### PR TITLE
Removed redundant code in search functions

### DIFF
--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -155,7 +155,7 @@ Sonos.prototype.searchMusicLibrary = function (searchType, searchTerm, options, 
         return (new xml2js.Parser()).parseString(data.Result, function (err, didl) {
             if (err) return callback(err, data)
             var items = []
-            if ((!didl) || (!didl['DIDL-Lite']) || (!util.isArray(didl['DIDL-Lite'].item))) {
+            if ((!didl) || (!didl['DIDL-Lite'])) {
                 callback(new Error('Cannot parse DIDTL result'), data)
             }
             var resultcontainer = opensearch ? didl['DIDL-Lite'].container : didl['DIDL-Lite'].item

--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -104,77 +104,19 @@ Sonos.prototype.request = function (endpoint, action, body, responseTag, callbac
 /**
  * Get Music Library Information
  * @param  {String}   searchType  Choice - artists, albumArtists, albums, genres, composers, tracks, playlists, share
- * @param  {Object}   options     Opitional - default {start: 0, total: 100}
+ * @param  {Object}   options     Optional - default {start: 0, total: 100}
  * @param  {Function} callback (err, result) result - {returned: {String}, total: {String}, items:[{title:{String}, uri: {String}}]}
  */
 Sonos.prototype.getMusicLibrary = function (searchType, options, callback) {
-  var self = this
-  var searches = {
-    'artists': 'A:ARTIST',
-    'albumArtists': 'A:ALBUMARTIST',
-    'albums': 'A:ALBUM',
-    'genres': 'A:GENRE',
-    'composers': 'A:COMPOSER',
-    'tracks': 'A:TRACKS',
-    'playlists': 'A:PLAYLISTS',
-    'share': 'S:'
-  }
-  var defaultOptions = {
-    BrowseFlag: 'BrowseDirectChildren',
-    Filter: '*',
-    StartingIndex: '0',
-    RequestedCount: '100',
-    SortCriteria: ''
-  }
-  var opts = {
-    ObjectID: searches[searchType]
-  }
-  if (options.start !== undefined) opts.StartingIndex = options.start
-  if (options.total !== undefined) opts.RequestedCount = options.total
-  opts = _.extend(defaultOptions, opts)
-  var contentDirectory = new Services.ContentDirectory(this.host, this.port)
-  return contentDirectory.Browse(opts, function (err, data) {
-    if (err) return callback(err)
-    return (new xml2js.Parser()).parseString(data.Result, function (err, didl) {
-      if (err) return callback(err, data)
-      var items = []
-      if ((!didl) || (!didl['DIDL-Lite']) || (!util.isArray(didl['DIDL-Lite'].container))) {
-        callback(new Error('Cannot parse DIDTL result'), data)
-      }
-      _.each(didl['DIDL-Lite'].container, function (item) {
-        var albumArtURL = null
-        if (util.isArray(item['upnp:albumArtURI'])) {
-          if (item['upnp:albumArtURI'][0].indexOf('http') !== -1) {
-            albumArtURL = item['upnp:albumArtURI'][0]
-          } else {
-            albumArtURL = 'http://' + self.host + ':' + self.port + item['upnp:albumArtURI'][0]
-          }
-        }
-        items.push(
-          {
-            'title': util.isArray(item['dc:title']) ? item['dc:title'][0] : null,
-            'artist': util.isArray(item['dc:creator']) ? item['dc:creator'][0] : null,
-            'albumArtURL': albumArtURL,
-            'uri': util.isArray(item.res) ? item.res[0]._ : null
-          }
-        )
-      })
-      var result = {
-        returned: data.NumberReturned,
-        total: data.TotalMatches,
-        items: items
-      }
-      return callback(null, result)
-    })
-  })
+    this.searchMusicLibrary(searchType, null, options, callback)
 }
 
 
 /**
  * Get Music Library Information
  * @param  {String}   searchType  Choice - artists, albumArtists, albums, genres, composers, tracks, playlists, share
- * @param  {String}   searchTerm  search term to search for
- * @param  {Object}   options     Opitional - default {start: 0, total: 100}
+ * @param  {String}   searchTerm  Optional - search term to search for
+ * @param  {Object}   options     Optional - default {start: 0, total: 100}
  * @param  {Function} callback (err, result) result - {returned: {String}, total: {String}, items:[{title:{String}, uri: {String}}]}
  */
 Sonos.prototype.searchMusicLibrary = function (searchType, searchTerm, options, callback) {
@@ -196,11 +138,16 @@ Sonos.prototype.searchMusicLibrary = function (searchType, searchTerm, options, 
         RequestedCount: '100',
         SortCriteria: ''
     }
-    var searches = searches[searchType] + ':' + searchTerm
+    var searches = searches[searchType]
+
+    var opensearch = (!searchTerm) || (searchTerm === '');
+    if (!opensearch) searches.concat(':' + searchTerm)
+
     var opts = {
         ObjectID: searches
     }
-    
+    if (options.start !== undefined) opts.StartingIndex = options.start
+    if (options.total !== undefined) opts.RequestedCount = options.total
     opts = _.extend(defaultOptions, opts)
     var contentDirectory = new Services.ContentDirectory(this.host, this.port)
     return contentDirectory.Browse(opts, function (err, data) {
@@ -211,7 +158,11 @@ Sonos.prototype.searchMusicLibrary = function (searchType, searchTerm, options, 
             if ((!didl) || (!didl['DIDL-Lite']) || (!util.isArray(didl['DIDL-Lite'].item))) {
                 callback(new Error('Cannot parse DIDTL result'), data)
             }
-            _.each(didl['DIDL-Lite'].item, function (item) {
+            var resultcontainer = opensearch ? didl['DIDL-Lite'].container : didl['DIDL-Lite'].item
+            if (!util.isArray(resultcontainer)) {
+                callback(new Error('Cannot parse DIDTL result'), data)
+            }
+            _.each(resultcontainer, function (item) {
                 var albumArtURL = null
                 if (util.isArray(item['upnp:albumArtURI'])) {
                     if (item['upnp:albumArtURI'][0].indexOf('http') !== -1) {


### PR DESCRIPTION
As the `Sonos.prototype.getMusicLibrary` and `Sonos.prototype.searchMusicLibrary`-methods had quite some code in common I made searchMusicLibrary able to take null as searchTerm-argument and made getMusicLibrary a wrapper function.