### PR TITLE
Fix discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 *.log
+.nyc_output

--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -16,6 +16,8 @@ var xml2js = require('xml2js')
 var debug = require('debug')('sonos')
 var fs = require('fs')
 var _ = require('underscore')
+var ip = require('ip')
+var os = require('os')
 
 /**
  * Services
@@ -814,8 +816,15 @@ Sonos.prototype.getCurrentState = function (callback) {
  */
 var Search = function Search (options) {
   var self = this
+
+  var netInterfaces = os.networkInterfaces()
+  debug('netInterfaces:', netInterfaces)
+  var eth0 = netInterfaces['eth0'][0]
+  debug('eth0: ', eth0)
+  var subnet = ip.subnet(eth0.address, eth0.netmask)
+  debug('subnet: ', subnet)
   var PLAYER_SEARCH = new Buffer(['M-SEARCH * HTTP/1.1',
-    'HOST: 239.255.255.250:1900',
+    'HOST: ' + subnet.broadcastAddress + ':1900',
     'MAN: ssdp:discover',
     'MX: 1',
     'ST: urn:schemas-upnp-org:device:ZonePlayer:1'].join('\r\n'))
@@ -832,7 +841,7 @@ var Search = function Search (options) {
   })
   this.socket.bind(function () {
     self.socket.setBroadcast(true)
-    self.socket.send(PLAYER_SEARCH, 0, PLAYER_SEARCH.length, 1900, '239.255.255.250')
+    self.socket.send(PLAYER_SEARCH, 0, PLAYER_SEARCH.length, 1900, subnet.broadcastAddress)
   })
   if (options.timeout) {
     setTimeout(function () {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "lint": "standard",
     "test": "mocha test/",
+    "coverage": "nyc npm test",
     "env-run": "npm run $CMD"
   },
   "repository": {
@@ -44,6 +45,7 @@
   },
   "devDependencies": {
     "mocha": "2.3.3",
+    "nyc": "^3.2.2",
     "standard": "3.13.2"
   }
 }

--- a/test/onsite.js
+++ b/test/onsite.js
@@ -1,0 +1,10 @@
+const assert = require('assert')
+const sonos = require('../')
+
+describe('sonos.search()', function () {
+  it('finds a sonos device', function (done) {
+    sonos.search(function (dev) {
+      done()
+    })
+  })
+})

--- a/test/onsite.js
+++ b/test/onsite.js
@@ -1,4 +1,4 @@
-const assert = require('assert')
+/* eslint-env mocha */
 const sonos = require('../')
 
 describe('sonos.search()', function () {


### PR DESCRIPTION
At the moment this will look for a net interface called eth0 and send/receive discovery packet on that network.

I'm not sure how Sonos do this, whether they send/listen on every network or limit to networks using specific IP ranges maybe as most the time Sonos devices are probably going to be on 192.168.x.x.

If anyone's more clued up on this than I am at the moment, please send pointers!