### PR TITLE
Fix browserify by importing specific modules

### DIFF
--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -14,16 +14,24 @@ var dgram = require('dgram')
 var request = require('request')
 var xml2js = require('xml2js')
 var debug = require('debug')('sonos')
-var fs = require('fs')
 var _ = require('underscore')
 
 /**
  * Services
  */
-var Services = {}
-fs.readdirSync(__dirname + '/services').forEach(function (filename) {
-  Services[filename.match(/^(.+)\.js$/)[1]] = require(__dirname + '/services/' + filename)
-})
+var Services = {
+  AlarmClock: require('./services/AlarmClock'),
+  AudioIn: require('./services/AudioIn'),
+  AVTransport: require('./services/AVTransport'),
+  ContentDirectory: require('./services/ContentDirectory'),
+  DeviceProperties: require('./services/DeviceProperties'),
+  GroupManagement: require('./services/GroupManagement'),
+  MusicServices: require('./services/MusicServices'),
+  RenderingControl: require('./services/RenderingControl'),
+  Service: require('./services/Service'),
+  SystemProperties: require('./services/SystemProperties'),
+  ZoneGroupTopology: require('./services/ZoneGroupTopology')
+}
 
 /**
  * Helpers


### PR DESCRIPTION
Hard-code list of Sonos service modules to import. This allows us to browserify this module as browserify requires local module names to be a simple string and not something evaluated.