### PR TITLE
Improve Sonos device discovery robustness

### DIFF
--- a/API.md
+++ b/API.md
@@ -409,3 +409,16 @@ Create a Search Instance (emits 'DeviceAvailable' with a found Sonos Component)
 
 {Search/EventEmitter Instance}
 * * *
+
+
+###Search.prototype.destroy = function(callback)###
+
+Stops searching and destroy the Search object
+####Parameters####
+
+* callback *Function* ()
+
+####Returns####
+
+*[type]* undefined
+* * *

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ For detailed info read the [/API.md](https://github.com/bencevans/node-sonos/blo
 * search([deviceAvailableListener])
 * Class: Search()
   * Event: 'DeviceAvailable'
+  * destroy()
 * Class: Sonos(host, [port])
   * currentTrack(callback)
   * deviceDescription(callback)

--- a/examples/search.js
+++ b/examples/search.js
@@ -1,6 +1,14 @@
 var Sonos = require('../')
+
+console.log('Searching for Sonos devices...')
 var search = Sonos.search()
 
 search.on('DeviceAvailable', function (device, model) {
   console.log(device, model)
 })
+
+// Optionally stop searching and destroy after some time
+setTimeout(function () {
+  console.log('Stop searching for Sonos devices')
+  search.destroy()
+}, 30000)

--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -834,7 +834,7 @@ var Search = function Search (options) {
       self.socket.send(PLAYER_SEARCH, 0, PLAYER_SEARCH.length, 1900, addr)
     })
     // Periodically send discover packet to find newly added devices
-    setTimeout(sendDiscover, 10000)
+    self.pollTimer = setTimeout(sendDiscover, 10000)
   }
   this.socket = dgram.createSocket('udp4', function (buffer, rinfo) {
     buffer = buffer.toString()
@@ -856,7 +856,7 @@ var Search = function Search (options) {
     sendDiscover()
   })
   if (options.timeout) {
-    setTimeout(function () {
+    self.searchTimer = setTimeout(function () {
       self.socket.close()
       self.emit('timeout')
     }, options.timeout)
@@ -864,6 +864,18 @@ var Search = function Search (options) {
   return this
 }
 util.inherits(Search, EventEmitter)
+
+/**
+ * Destroys Search class, stop searching, clean up
+ *
+ * @param  {Function} callback ()
+ */
+Search.prototype.destroy = function (callback) {
+  clearTimeout(this.searchTimer)
+  clearTimeout(this.pollTimer)
+  this.socket.close(callback)
+}
+
 /**
  * Create a Search Instance (emits 'DeviceAvailable' with a found Sonos Component)
  * @param  {Object} options Optional Options to control search behavior.

--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -823,17 +823,29 @@ Sonos.prototype.getCurrentState = function (callback) {
  */
 var Search = function Search (options) {
   var self = this
+  self.foundSonosDevices = {}
   var PLAYER_SEARCH = new Buffer(['M-SEARCH * HTTP/1.1',
     'HOST: 239.255.255.250:1900',
     'MAN: ssdp:discover',
     'MX: 1',
     'ST: urn:schemas-upnp-org:device:ZonePlayer:1'].join('\r\n'))
+  var sendDiscover = function () {
+    ['239.255.255.250', '255.255.255.255'].map(function (addr) {
+      self.socket.send(PLAYER_SEARCH, 0, PLAYER_SEARCH.length, 1900, addr)
+    })
+    // Periodically send discover packet to find newly added devices
+    setTimeout(sendDiscover, 10000)
+  }
   this.socket = dgram.createSocket('udp4', function (buffer, rinfo) {
     buffer = buffer.toString()
     if (buffer.match(/.+Sonos.+/)) {
       var modelCheck = buffer.match(/SERVER.*\((.*)\)/)
       var model = (modelCheck.length > 1 ? modelCheck[1] : null)
-      self.emit('DeviceAvailable', new Sonos(rinfo.address), model)
+      var addr = rinfo.address
+      if (!(addr in self.foundSonosDevices)) {
+        var sonos = self.foundSonosDevices[addr] = new Sonos(addr)
+        self.emit('DeviceAvailable', sonos, model)
+      }
     }
   })
   this.socket.on('error', function (err) {
@@ -841,7 +853,7 @@ var Search = function Search (options) {
   })
   this.socket.bind(function () {
     self.socket.setBroadcast(true)
-    self.socket.send(PLAYER_SEARCH, 0, PLAYER_SEARCH.length, 1900, '239.255.255.250')
+    sendDiscover()
   })
   if (options.timeout) {
     setTimeout(function () {

--- a/test/sonos.test.js
+++ b/test/sonos.test.js
@@ -130,4 +130,17 @@ describe('search', function () {
       done()
     })
   })
+
+  it('should not emit a timeout event after search is stopped', function (done) {
+    var search = sonos.search({ timeout: 10 }, function (device, model) {})
+
+    search.on('timeout', function () {
+      assert(false, 'Timeout event should never fire')
+      done()
+    })
+    search.destroy(function () {
+      assert(true)
+      done()
+    })
+  })
 })


### PR DESCRIPTION
This change more closely mimics what the Sonos desktop add does for device discovery. It fixed some of the discovery issues I was seeing. The desktop app does more yet: is more aggressive with polling, listens for notify messages from Sonos devices.