### PR TITLE
Support Spotify track uri for Play and Queue apis

### DIFF
--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -66,13 +66,12 @@ var htmlEntities = function (str) {
 var optionsFromSpotifyUri = function (uri, title) {
   var spotifyIds = uri.split(':')
   if (Array.isArray(spotifyIds) && spotifyIds.length < 3) return uri
-  var spotifyUri =  uri.replace(/:/g, '%3a')
-  var spotifyResourceId = spotifyIds[2];
+  var spotifyUri = uri.replace(/:/g, '%3a')
   var meta = '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"><item id="##SPOTIFYURI##" restricted="true"><dc:title>##RESOURCETITLE##</dc:title><upnp:class>##SPOTIFYTYPE##</upnp:class><desc id="cdudn" nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">SA_RINCON3079_X_#Svc3079-0-Token</desc></item></DIDL-Lite>'
   if (uri.startsWith('spotify:track:')) {
     return {
       uri: spotifyUri,
-      metadata: meta.replace('##SPOTIFYURI##', '00032020' + spotifyUri).replace('##RESOURCETITLE##','').replace('##SPOTIFYTYPE##', 'object.item.audioItem.musicTrack')
+      metadata: meta.replace('##SPOTIFYURI##', '00032020' + spotifyUri).replace('##RESOURCETITLE##', '').replace('##SPOTIFYTYPE##', 'object.item.audioItem.musicTrack')
     }
   } else if (uri.startsWith('spotify:artistTopTracks:')) {
     return {
@@ -326,7 +325,7 @@ Sonos.prototype.play = function (uri, callback) {
   var body
   var self = this
   var cb = (typeof uri === 'function' ? uri : callback) || function () {}
-  if (typeof uri === 'string') uri = optionsFromSpotifyTrackUri(uri)
+  if (typeof uri === 'string') uri = optionsFromSpotifyUri(uri)
   var options = (typeof uri === 'object' ? uri : {})
   if (typeof uri === 'object') {
     options.uri = uri.uri
@@ -578,7 +577,7 @@ Sonos.prototype.addSpotify = function (track_id, callback) {
 
 /**
  * Plays Spotify radio based on artist uri
- * @param  {String}   artistId  Spotify artist id      
+ * @param  {String}   artistId  Spotify artist id
  * @param  {Function} callback (err, playing)
  */
 Sonos.prototype.playSpotifyRadio = function (artistId, artistName, callback) {

--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -71,8 +71,7 @@ var optionsFromSpotifyTrackUri = function (uri) {
       uri: uri.replace(/:/g, '%3a'),
       metadata: meta
     }
-  }
-  else {
+  } else {
     return uri
   }
 }

--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -312,9 +312,7 @@ Sonos.prototype.play = function (uri, callback) {
   var body
   var self = this
   var cb = (typeof uri === 'function' ? uri : callback) || function () {}
-  
   if (typeof uri === 'string') uri = optionsFromSpotifyTrackUri(uri)
-  
   var options = (typeof uri === 'object' ? uri : {})
   if (typeof uri === 'object') {
     options.uri = uri.uri
@@ -330,11 +328,11 @@ Sonos.prototype.play = function (uri, callback) {
       if (err || !queueResult || queueResult.length < 0 || !queueResult[0].FirstTrackNumberEnqueued) {
         return cb(err)
       }
-      
       var selectTrackNum = queueResult[0].FirstTrackNumberEnqueued[0]
-      self.selectTrack(selectTrackNum, function (err, trackResult) {
+      self.selectTrack(selectTrackNum, function (err) {
+        if (err) return cb(err)
         return self.play(cb)
-      });
+      })
     })
   } else {
     action = '"urn:schemas-upnp-org:service:AVTransport:1#Play"'
@@ -579,7 +577,6 @@ Sonos.prototype.queueNext = function (uri, callback) {
   } else {
     options.uri = uri
   }
-  
   var action = '"urn:schemas-upnp-org:service:AVTransport:1#SetAVTransportURI"'
   var body = '<u:SetAVTransportURI xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><CurrentURI>' + options.uri + '</CurrentURI><CurrentURIMetaData>' + options.metadata + '</CurrentURIMetaData></u:SetAVTransportURI>'
   this.request(this.options.endpoints.transport, action, body, 'u:SetAVTransportURIResponse', function (err, data) {
@@ -604,9 +601,7 @@ Sonos.prototype.queue = function (uri, positionInQueue, callback) {
     callback = positionInQueue
     positionInQueue = 0
   }
-  
   if (typeof uri === 'string') uri = optionsFromSpotifyTrackUri(uri)
-  
   var options = (typeof uri === 'object' ? uri : { metadata: '' })
   if (typeof uri === 'object') {
     options.metadata = uri.metadata || ''

--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -45,7 +45,7 @@ var Services = {
 var withinEnvelope = function (body) {
   return ['<?xml version="1.0" encoding="utf-8"?>',
     '<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">',
-    '  <s:Body>' + body + '</s:Body>',
+    '<s:Body>' + body + '</s:Body>',
     '</s:Envelope>'].join('')
 }
 
@@ -61,15 +61,29 @@ var htmlEntities = function (str) {
 /**
  * Creates object with uri and metadata from Spotify track uri
  * @param  {String} uri
- * @return {Object} options       {uri: Spotify track uri, metadata: metadata}
+ * @return {Object} options       {uri: Spotify uri, metadata: metadata}
  */
-var optionsFromSpotifyTrackUri = function (uri) {
-  if (uri && uri.startsWith('spotify:track:')) {
-    var track_id = uri.split(':')[2]
-    var meta = '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"><item id="00032020spotify%3atrack%3a' + track_id + '" restricted="true"><dc:title></dc:title><upnp:class>object.item.audioItem.musicTrack</upnp:class><desc id="cdudn" nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">SA_RINCON3079_X_#Svc3079-0-Token</desc></item></DIDL-Lite>'
+var optionsFromSpotifyUri = function (uri, title) {
+  var spotifyIds = uri.split(':')
+  if (Array.isArray(spotifyIds) && spotifyIds.length < 3) return uri
+  var spotifyUri =  uri.replace(/:/g, '%3a')
+  var spotifyResourceId = spotifyIds[2];
+  var meta = '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"><item id="##SPOTIFYURI##" restricted="true"><dc:title>##RESOURCETITLE##</dc:title><upnp:class>##SPOTIFYTYPE##</upnp:class><desc id="cdudn" nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">SA_RINCON3079_X_#Svc3079-0-Token</desc></item></DIDL-Lite>'
+  if (uri.startsWith('spotify:track:')) {
     return {
-      uri: uri.replace(/:/g, '%3a'),
-      metadata: meta
+      uri: spotifyUri,
+      metadata: meta.replace('##SPOTIFYURI##', '00032020' + spotifyUri).replace('##RESOURCETITLE##','').replace('##SPOTIFYTYPE##', 'object.item.audioItem.musicTrack')
+    }
+  } else if (uri.startsWith('spotify:artistTopTracks:')) {
+    return {
+      uri: 'x-rincon-cpcontainer:000e206c' + spotifyUri,
+      metadata: meta.replace('##SPOTIFYURI##', '000e206c' + spotifyUri).replace('##RESOURCETITLE##', 'Top Tracks').replace('##SPOTIFYTYPE##', 'object.container.playlistContainer')
+    }
+  } else if (uri.startsWith('spotify:artistRadio:')) {
+    var radioTitle = (title !== undefined) ? title : 'Radio'
+    return {
+      uri: spotifyUri,
+      metadata: '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"><item id="000c206c' + spotifyUri + '" restricted="true"><dc:title>' + radioTitle + '</dc:title><upnp:class>object.item.audioItem.audioBroadcast.#artistRadio</upnp:class><desc id="cdudn" nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">SA_RINCON3079_X_#Svc3079-0-Token</desc></item></DIDL-Lite>'
     }
   } else {
     return uri
@@ -563,6 +577,33 @@ Sonos.prototype.addSpotify = function (track_id, callback) {
 }
 
 /**
+ * Plays Spotify radio based on artist uri
+ * @param  {String}   artistId  Spotify artist id      
+ * @param  {Function} callback (err, playing)
+ */
+Sonos.prototype.playSpotifyRadio = function (artistId, artistName, callback) {
+  debug('Sonos.playSpotifyRadio(%j, %j, %j)', artistId, artistName, callback)
+  var self = this
+  if (!artistId || !artistName) {
+    return callback(new Error('artistId and artistName are required'))
+  }
+  var options = optionsFromSpotifyUri('spotify:artistRadio:' + artistId, artistName)
+  var action = '"urn:schemas-upnp-org:service:AVTransport:1#SetAVTransportURI"'
+  var body = '<u:SetAVTransportURI xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><CurrentURI>x-sonosapi-radio:' + options.uri + '?sid=12&amp;flags=8300&amp;sn=1</CurrentURI><CurrentURIMetaData>' + htmlEntities(options.metadata) + '</CurrentURIMetaData></u:SetAVTransportURI>'
+  return this.request(this.options.endpoints.transport, action, body, 'u:SetAVTransportURIResponse', function (err, data) {
+    if (err) return callback(err)
+    if (data[0].$['xmlns:u'] === 'urn:schemas-upnp-org:service:AVTransport:1') {
+      return self.play(callback)
+    } else {
+      return callback(new Error({
+        err: err,
+        data: data
+      }), false)
+    }
+  })
+}
+
+/**
  * Queue a Song Next
  * @param  {String|Object}   uri      URI to Audio Stream or Object containing options (uri, metadata)
  * @param  {Function} callback (err, queued)
@@ -601,7 +642,7 @@ Sonos.prototype.queue = function (uri, positionInQueue, callback) {
     callback = positionInQueue
     positionInQueue = 0
   }
-  if (typeof uri === 'string') uri = optionsFromSpotifyTrackUri(uri)
+  if (typeof uri === 'string') uri = optionsFromSpotifyUri(uri)
   var options = (typeof uri === 'object' ? uri : { metadata: '' })
   if (typeof uri === 'object') {
     options.metadata = uri.metadata || ''

--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -59,6 +59,25 @@ var htmlEntities = function (str) {
 }
 
 /**
+ * Creates object with uri and metadata from Spotify track uri
+ * @param  {String} uri
+ * @return {Object} options       {uri: Spotify track uri, metadata: metadata}
+ */
+var optionsFromSpotifyTrackUri = function (uri) {
+  if (uri && uri.startsWith('spotify:track:')) {
+    var track_id = uri.split(':')[2]
+    var meta = '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"><item id="00032020spotify%3atrack%3a' + track_id + '" restricted="true"><dc:title></dc:title><upnp:class>object.item.audioItem.musicTrack</upnp:class><desc id="cdudn" nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">SA_RINCON3079_X_#Svc3079-0-Token</desc></item></DIDL-Lite>'
+    return {
+      uri: uri.replace(/:/g, '%3a'),
+      metadata: meta
+    }
+  }
+  else {
+    return uri
+  }
+}
+
+/**
  * Sonos "Class"
  * @param {String} host IP/DNS
  * @param {Number} port
@@ -294,6 +313,9 @@ Sonos.prototype.play = function (uri, callback) {
   var body
   var self = this
   var cb = (typeof uri === 'function' ? uri : callback) || function () {}
+  
+  if (typeof uri === 'string') uri = optionsFromSpotifyTrackUri(uri)
+  
   var options = (typeof uri === 'object' ? uri : {})
   if (typeof uri === 'object') {
     options.uri = uri.uri
@@ -302,14 +324,18 @@ Sonos.prototype.play = function (uri, callback) {
     options.uri = (typeof uri === 'string' ? uri : undefined)
   }
   if (options.uri) {
-    return this.queueNext({
+    return this.queue({
       uri: options.uri,
       metadata: options.metadata
-    }, function (err) {
-      if (err) {
+    }, function (err, queueResult) {
+      if (err || !queueResult || queueResult.length < 0 || !queueResult[0].FirstTrackNumberEnqueued) {
         return cb(err)
       }
-      return self.play(cb)
+      
+      var selectTrackNum = queueResult[0].FirstTrackNumberEnqueued[0]
+      self.selectTrack(selectTrackNum, function (err, trackResult) {
+        return self.play(cb)
+      });
     })
   } else {
     action = '"urn:schemas-upnp-org:service:AVTransport:1#Play"'
@@ -530,13 +556,10 @@ Sonos.prototype.selectQueue = function (callback) {
  * @param  {Function} callback (err, success)
  */
 Sonos.prototype.addSpotify = function (track_id, callback) {
-  // var rand = Math.floor(Math.random()*(99999999-10000000+1)+10000000)
-  var rand = '00030020'
   var uri = 'x-sonos-spotify:spotify%3atrack%3a' + track_id
+  var meta = '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"><item id="00032020spotify%3atrack%3a' + track_id + '" restricted="true"><dc:title></dc:title><upnp:class>object.item.audioItem.musicTrack</upnp:class><desc id="cdudn" nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">SA_RINCON3079_X_#Svc3079-0-Token</desc></item></DIDL-Lite>'
 
-  var meta = '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"><item id="' + rand + 'spotify%3atrack%3a' + track_id + '" restricted="true"><dc:title></dc:title><upnp:class>object.item.audioItem.musicTrack</upnp:class><desc id="cdudn" nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">SA_RINCON2311_X_#Svc2311-0-Token</desc></item></DIDL-Lite>'
-
-  this.queueNext({
+  this.queue({
     uri: uri,
     metadata: meta
   }, callback)
@@ -557,6 +580,7 @@ Sonos.prototype.queueNext = function (uri, callback) {
   } else {
     options.uri = uri
   }
+  
   var action = '"urn:schemas-upnp-org:service:AVTransport:1#SetAVTransportURI"'
   var body = '<u:SetAVTransportURI xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><CurrentURI>' + options.uri + '</CurrentURI><CurrentURIMetaData>' + options.metadata + '</CurrentURIMetaData></u:SetAVTransportURI>'
   this.request(this.options.endpoints.transport, action, body, 'u:SetAVTransportURIResponse', function (err, data) {
@@ -581,6 +605,9 @@ Sonos.prototype.queue = function (uri, positionInQueue, callback) {
     callback = positionInQueue
     positionInQueue = 0
   }
+  
+  if (typeof uri === 'string') uri = optionsFromSpotifyTrackUri(uri)
+  
   var options = (typeof uri === 'object' ? uri : { metadata: '' })
   if (typeof uri === 'object') {
     options.metadata = uri.metadata || ''

--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -73,13 +73,23 @@ var optionsFromSpotifyUri = function (uri, title) {
       uri: spotifyUri,
       metadata: meta.replace('##SPOTIFYURI##', '00032020' + spotifyUri).replace('##RESOURCETITLE##', '').replace('##SPOTIFYTYPE##', 'object.item.audioItem.musicTrack')
     }
+  } else if (uri.startsWith('spotify:album:')) {
+    return {
+      uri: 'x-rincon-cpcontainer:0004206c' + spotifyUri,
+      metadata: meta.replace('##SPOTIFYURI##', '0004206c' + spotifyUri).replace('##RESOURCETITLE##', '').replace('##SPOTIFYTYPE##', 'object.container.album.musicAlbum')
+    }
   } else if (uri.startsWith('spotify:artistTopTracks:')) {
     return {
       uri: 'x-rincon-cpcontainer:000e206c' + spotifyUri,
-      metadata: meta.replace('##SPOTIFYURI##', '000e206c' + spotifyUri).replace('##RESOURCETITLE##', 'Top Tracks').replace('##SPOTIFYTYPE##', 'object.container.playlistContainer')
+      metadata: meta.replace('##SPOTIFYURI##', '000e206c' + spotifyUri).replace('##RESOURCETITLE##', '').replace('##SPOTIFYTYPE##', 'object.container.playlistContainer')
+    }
+  } else if (uri.startsWith('spotify:user:')) {
+    return {
+      uri: 'x-rincon-cpcontainer:0006206c' + spotifyUri,
+      metadata: meta.replace('##SPOTIFYURI##', '0006206c' + spotifyUri).replace('##RESOURCETITLE##', '').replace('##SPOTIFYTYPE##', 'object.container.playlistContainer')
     }
   } else if (uri.startsWith('spotify:artistRadio:')) {
-    var radioTitle = (title !== undefined) ? title : 'Radio'
+    var radioTitle = (title !== undefined) ? title : 'Artist Radio'
     return {
       uri: spotifyUri,
       metadata: '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"><item id="000c206c' + spotifyUri + '" restricted="true"><dc:title>' + radioTitle + '</dc:title><upnp:class>object.item.audioItem.audioBroadcast.#artistRadio</upnp:class><desc id="cdudn" nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">SA_RINCON3079_X_#Svc3079-0-Token</desc></item></DIDL-Lite>'

--- a/test/sonos.test.js
+++ b/test/sonos.test.js
@@ -28,10 +28,21 @@ describe('Sonos', function () {
 
         if (actionCounter === 1) {
           assert(endpoint === '/MediaRenderer/AVTransport/Control')
-          assert(action === '"urn:schemas-upnp-org:service:AVTransport:1#SetAVTransportURI"')
-          assert(body === '<u:SetAVTransportURI xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><CurrentURI>http://livingears.com/music/SceneNotHeard/091909/Do You Mind Kyla.mp3</CurrentURI><CurrentURIMetaData></CurrentURIMetaData></u:SetAVTransportURI>')
-          callback(null)
+          assert(action === '"urn:schemas-upnp-org:service:AVTransport:1#AddURIToQueue"')
+          assert(body === '<u:AddURIToQueue xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><EnqueuedURI>http://livingears.com/music/SceneNotHeard/091909/Do You Mind Kyla.mp3</EnqueuedURI><EnqueuedURIMetaData></EnqueuedURIMetaData><DesiredFirstTrackNumberEnqueued>0</DesiredFirstTrackNumberEnqueued><EnqueueAsNext>1</EnqueueAsNext></u:AddURIToQueue>')
+          callback(null, [{
+              FirstTrackNumberEnqueued: ['1'],
+              NewQueueLength: ['1'],
+              NumTracksAdded: ['1']
+          }])
         } else if (actionCounter === 2) {
+          assert(endpoint === '/MediaRenderer/AVTransport/Control')
+          assert(action === '"urn:schemas-upnp-org:service:AVTransport:1#Seek"')
+          assert(body === '<u:Seek xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><Unit>TRACK_NR</Unit><Target>1</Target></u:Seek>')
+          callback(null, [{
+              $: {'xmlns:u':'urn:schemas-upnp-org:service:AVTransport:1'}
+          }])
+        } else if (actionCounter === 3) {
           assert(endpoint === '/MediaRenderer/AVTransport/Control')
           assert(action === '"urn:schemas-upnp-org:service:AVTransport:1#Play"')
           assert(body === '<u:Play xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><Speed>1</Speed></u:Play>')
@@ -52,10 +63,21 @@ describe('Sonos', function () {
 
         if (actionCounter === 1) {
           assert(endpoint === '/MediaRenderer/AVTransport/Control')
-          assert(action === '"urn:schemas-upnp-org:service:AVTransport:1#SetAVTransportURI"')
-          assert(body === '<u:SetAVTransportURI xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><CurrentURI>http://livingears.com/music/SceneNotHeard/091909/Do You Mind Kyla.mp3</CurrentURI><CurrentURIMetaData>test</CurrentURIMetaData></u:SetAVTransportURI>')
-          callback(null)
+          assert(action === '"urn:schemas-upnp-org:service:AVTransport:1#AddURIToQueue"')
+          assert(body === '<u:AddURIToQueue xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><EnqueuedURI>http://livingears.com/music/SceneNotHeard/091909/Do You Mind Kyla.mp3</EnqueuedURI><EnqueuedURIMetaData>test</EnqueuedURIMetaData><DesiredFirstTrackNumberEnqueued>0</DesiredFirstTrackNumberEnqueued><EnqueueAsNext>1</EnqueueAsNext></u:AddURIToQueue>')
+          callback(null, [{
+              FirstTrackNumberEnqueued: ['1'],
+              NewQueueLength: ['1'],
+              NumTracksAdded: ['1']
+          }])
         } else if (actionCounter === 2) {
+          assert(endpoint === '/MediaRenderer/AVTransport/Control')
+          assert(action === '"urn:schemas-upnp-org:service:AVTransport:1#Seek"')
+          assert(body === '<u:Seek xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><Unit>TRACK_NR</Unit><Target>1</Target></u:Seek>')
+          callback(null, [{
+              $: {'xmlns:u':'urn:schemas-upnp-org:service:AVTransport:1'}
+          }])
+        } else if (actionCounter === 3) {
           assert(endpoint === '/MediaRenderer/AVTransport/Control')
           assert(action === '"urn:schemas-upnp-org:service:AVTransport:1#Play"')
           assert(body === '<u:Play xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><Speed>1</Speed></u:Play>')

--- a/test/sonos.test.js
+++ b/test/sonos.test.js
@@ -31,16 +31,16 @@ describe('Sonos', function () {
           assert(action === '"urn:schemas-upnp-org:service:AVTransport:1#AddURIToQueue"')
           assert(body === '<u:AddURIToQueue xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><EnqueuedURI>http://livingears.com/music/SceneNotHeard/091909/Do You Mind Kyla.mp3</EnqueuedURI><EnqueuedURIMetaData></EnqueuedURIMetaData><DesiredFirstTrackNumberEnqueued>0</DesiredFirstTrackNumberEnqueued><EnqueueAsNext>1</EnqueueAsNext></u:AddURIToQueue>')
           callback(null, [{
-              FirstTrackNumberEnqueued: ['1'],
-              NewQueueLength: ['1'],
-              NumTracksAdded: ['1']
+            FirstTrackNumberEnqueued: ['1'],
+            NewQueueLength: ['1'],
+            NumTracksAdded: ['1']
           }])
         } else if (actionCounter === 2) {
           assert(endpoint === '/MediaRenderer/AVTransport/Control')
           assert(action === '"urn:schemas-upnp-org:service:AVTransport:1#Seek"')
           assert(body === '<u:Seek xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><Unit>TRACK_NR</Unit><Target>1</Target></u:Seek>')
           callback(null, [{
-              $: {'xmlns:u':'urn:schemas-upnp-org:service:AVTransport:1'}
+            $: {'xmlns:u': 'urn:schemas-upnp-org:service:AVTransport:1'}
           }])
         } else if (actionCounter === 3) {
           assert(endpoint === '/MediaRenderer/AVTransport/Control')
@@ -66,16 +66,16 @@ describe('Sonos', function () {
           assert(action === '"urn:schemas-upnp-org:service:AVTransport:1#AddURIToQueue"')
           assert(body === '<u:AddURIToQueue xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><EnqueuedURI>http://livingears.com/music/SceneNotHeard/091909/Do You Mind Kyla.mp3</EnqueuedURI><EnqueuedURIMetaData>test</EnqueuedURIMetaData><DesiredFirstTrackNumberEnqueued>0</DesiredFirstTrackNumberEnqueued><EnqueueAsNext>1</EnqueueAsNext></u:AddURIToQueue>')
           callback(null, [{
-              FirstTrackNumberEnqueued: ['1'],
-              NewQueueLength: ['1'],
-              NumTracksAdded: ['1']
+            FirstTrackNumberEnqueued: ['1'],
+            NewQueueLength: ['1'],
+            NumTracksAdded: ['1']
           }])
         } else if (actionCounter === 2) {
           assert(endpoint === '/MediaRenderer/AVTransport/Control')
           assert(action === '"urn:schemas-upnp-org:service:AVTransport:1#Seek"')
           assert(body === '<u:Seek xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><Unit>TRACK_NR</Unit><Target>1</Target></u:Seek>')
           callback(null, [{
-              $: {'xmlns:u':'urn:schemas-upnp-org:service:AVTransport:1'}
+            $: {'xmlns:u': 'urn:schemas-upnp-org:service:AVTransport:1'}
           }])
         } else if (actionCounter === 3) {
           assert(endpoint === '/MediaRenderer/AVTransport/Control')


### PR DESCRIPTION
Added support for passing a Spotify track uri to the ```Sonos.play``` and ```Sonos.queue``` apis.

I added a new helper function named ```optionsFromSpotifyTrackUri(uri)```
This function takes a Spotify uri in the form ```spotify:track:trackid``` and creates an options object of the form:
```
{
    uri: "spotify:track:<trackid>",
    metadata: "(meta data from original addSpotify function)"
}
```

This helper function is used in the ```Sonos.play``` and ```Sonos.queue``` apis to create the options/metadata object in the case when the caller passes a Spotify track uri.

```Sonos.play``` has been also been changed to call ```Sonos.queue``` rather than ```Sonos.queueNext``` since the SOAP envelope body needed to contain the ```<AddURIToQueue>``` node, which is the default for this api. I also added code to set the current track before initiating the play.

I left the ```Sonos.addSpotify``` api so it didn't break existing code that depended on it. However, I also updated it to call ```Sonos.queue``` rather than ```Sonos.queueNext``` for the same reason explained above.

I didn't change the ```Sonos.queueNext``` api as @bencevans suggested. I couldn't find a use for it and didn't understand how the ```<SetAVTransportURI>``` is used. It didn't support the metadata associated with Spotify track uris which is why I switched to using the ```Sonos.queue``` api.