### PR TITLE
Allow fixed listener port to be specified

### DIFF
--- a/lib/events/listener.js
+++ b/lib/events/listener.js
@@ -31,7 +31,7 @@ Listener.prototype._startInternalServer = function (callback) {
       req.body = buffer
       this._messageHandler(req, res)
     }.bind(this))
-  }.bind(this)).listen(0, function () {
+  }.bind(this)).listen(this.port, function () {
     if (this.port === 0) {
       this.port = this.server.address().port
     }

--- a/lib/events/listener.js
+++ b/lib/events/listener.js
@@ -6,15 +6,21 @@ var util = require('util')
 var _ = require('underscore')
 var events = require('events')
 
-var Listener = function (device) {
+var Listener = function (device, options) {
   this.device = device
   this.parser = new xml2js.Parser()
   this.services = {}
+  this.options = options || {}
 }
 
 util.inherits(Listener, events.EventEmitter)
 
 Listener.prototype._startInternalServer = function (callback) {
+  this.port = 0
+  if ("port" in this.options) {
+    this.port = this.options.port
+  }
+
   this.server = http.createServer(function (req, res) {
     var buffer = ''
     req.on('data', function (d) {
@@ -26,9 +32,10 @@ Listener.prototype._startInternalServer = function (callback) {
       this._messageHandler(req, res)
     }.bind(this))
   }.bind(this)).listen(0, function () {
-    var port = this.server.address().port
-    this.port = port
-    callback(null, port)
+    if (this.port === 0) {
+      this.port = this.server.address().port
+    }
+    callback(null, this.port)
 
     setInterval(this._renewServices.bind(this), 1 * 1000)
   }.bind(this))

--- a/lib/events/listener.js
+++ b/lib/events/listener.js
@@ -17,7 +17,7 @@ util.inherits(Listener, events.EventEmitter)
 
 Listener.prototype._startInternalServer = function (callback) {
   this.port = 0
-  if ("port" in this.options) {
+  if ('port' in this.options) {
     this.port = this.options.port
   }
 


### PR DESCRIPTION
I'm currently using homebridge-sonos and due to way the event listener works in node-sonos it listens for events on a random port. Unfortunately, I'm running this on a computer with a firewall.

This change adds options API to the listener so a custom fixed port can be specified. I plan to implement this in a contribution to homebridge-sonos. It should fallback gracefully to randomly generating a port if one is not specified.

Thanks!