### PR TITLE
Prevent eventemitter leak while searching for sonos devices

### DIFF
--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -1068,6 +1068,9 @@ Sonos.prototype.getQueue = function (callback) {
 var Search = function Search (options) {
   var self = this
   self.foundSonosDevices = {}
+  self.onTimeout = function () {
+    clearTimeout(self.pollTimer)
+  }
   var PLAYER_SEARCH = new Buffer(['M-SEARCH * HTTP/1.1',
     'HOST: 239.255.255.250:1900',
     'MAN: ssdp:discover',
@@ -1079,9 +1082,9 @@ var Search = function Search (options) {
     })
     // Periodically send discover packet to find newly added devices
     self.pollTimer = setTimeout(sendDiscover, 10000)
-    self.on('timeout', function () {
-      clearTimeout(self.pollTimer)
-    })
+    // Remove the on timeout listener and add back in every iteration
+    self.removeListener('timeout', self.onTimeout)
+    self.on('timeout', self.onTimeout)
   }
   this.socket = dgram.createSocket('udp4', function (buffer, rinfo) {
     buffer = buffer.toString()


### PR DESCRIPTION
Possible fix for https://github.com/bencevans/node-sonos/issues/157