### PR TITLE
clear timeouts on socket close

### DIFF
--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -1096,6 +1096,10 @@ var Search = function Search (options) {
       }
     }
   })
+  this.socket.on('close', function () {
+    clearTimeout(self.searchTimer)
+    clearTimeout(self.pollTimer)
+  })
   this.socket.on('error', function (err) {
     self.emit('error', err)
   })

--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -1097,7 +1097,9 @@ var Search = function Search (options) {
     }
   })
   this.socket.on('close', function () {
-    clearTimeout(self.searchTimer)
+    if (self.searchTimer) {
+      clearTimeout(self.searchTimer)
+    }
     clearTimeout(self.pollTimer)
   })
   this.socket.on('error', function (err) {


### PR DESCRIPTION
This is a fix for [dgram.js:527 throw new Error('Not running'); #4](https://github.com/bencevans/sonos-cli/issues/4) in the [sonos-cli](https://github.com/bencevans/sonos-cli) repo. The fix clears the timeouts (`searchTimer` and `pollTimer`) on the socket `close` event preventing `self.socket.send` from being called with a closed socket, resulting in `Error: Not running`.
