### PR TITLE
feat: Sonos can listen for events

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 node_js:
-  - 4
-  - 5
   - 6
-  - 7
+  - 8
+  - 9
 sudo: false
 matrix:
   fast_finish: true

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ For detailed info read the [/API.md](https://github.com/bencevans/node-sonos/blo
   * setVolume(volume, callback)
   * stop(callback)
   * setSpotifyRegion(region)
+  * startListening(options, callback)
+  * stopListening(callback)
+  * Event: 'TrackChanged'
+  * Event: 'VolumeChanged'
+  * Event: 'StateChanged'
+  * Event: 'Muted'
 
 ## Examples
 

--- a/examples/listenForEvents.js
+++ b/examples/listenForEvents.js
@@ -1,0 +1,30 @@
+var Sonos = require('../index').Sonos
+
+var sonos = new Sonos(process.env.SONOS_HOST || '192.168.96.56')
+
+sonos.startListening(function (err) {
+  console.log('Error startListening %s', err)
+})
+
+sonos.on('StateChanged', state => {
+  console.log('State changed to %s', state)
+})
+
+sonos.on('TrackChanged', track => {
+  console.log('Current track %s', track.title)
+})
+
+sonos.on('VolumeChanged', volume => {
+  console.log('Volume changed to %s', volume)
+})
+
+sonos.on('Muted', muted => {
+  console.log('Sonos muted %s', muted)
+})
+
+process.on('SIGINT', function () {
+  console.log('Shutting down listener')
+  sonos.stopListening(function () {
+    process.exit()
+  })
+})

--- a/examples/listenForEvents.js
+++ b/examples/listenForEvents.js
@@ -2,9 +2,11 @@ var Sonos = require('../index').Sonos
 
 var sonos = new Sonos(process.env.SONOS_HOST || '192.168.96.56')
 
-sonos.startListening(function (err) {
-  console.log('Error startListening %s', err)
-})
+// You don't need to call startListening anymore, is called implicit by subscribing
+// You can however if you want to specify a certain interface.
+// sonos.startListening(function (err, success) {
+//   console.log('Error startListening %s', err)
+// })
 
 sonos.on('StateChanged', state => {
   console.log('State changed to %s', state)

--- a/lib/events/listener.js
+++ b/lib/events/listener.js
@@ -179,4 +179,21 @@ Listener.prototype.removeService = function (sid, callback) {
   }
 }
 
+Listener.prototype.stop = function (callback) {
+  var self = this
+  var keys = Object.keys(this.services)
+  if (keys.length > 0) {
+    var sid = keys[0]
+    self.removeService(sid, function (err, success) {
+      if (!err && success) {
+        delete self.services[sid]
+      }
+      self.stop(callback)
+    })
+  } else {
+    delete self.server
+    callback(true)
+  }
+}
+
 module.exports = Listener

--- a/lib/events/listener.js
+++ b/lib/events/listener.js
@@ -192,7 +192,7 @@ Listener.prototype.stop = function (callback) {
     })
   } else {
     delete self.server
-    callback(true)
+    callback(null, true)
   }
 }
 

--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -1186,8 +1186,7 @@ Sonos.prototype.startListening = function (options, callback) {
   var self = this
   debug('Sonos.startListening(%j,%j)', options, callback)
   if (this.eventListener != null) {
-    callback('Already listening')
-    return
+    throw new Error('Already listening')
   }
   // Lets create a listener and start listening
   self.eventListener = new Listener(self, options)
@@ -1279,8 +1278,7 @@ Sonos.prototype.startListening = function (options, callback) {
 
 Sonos.prototype.stopListening = function (callback) {
   if (!this.eventListener) {
-    callback('Not listening')
-    return
+    throw new Error('Not listening')
   }
   this.eventListener.stop(success => {
     callback(null, true)

--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -5,6 +5,9 @@ var TRANSPORT_ENDPOINT = '/MediaRenderer/AVTransport/Control'
 var RENDERING_ENDPOINT = '/MediaRenderer/RenderingControl/Control'
 var DEVICE_ENDPOINT = '/DeviceProperties/Control'
 
+const TRANSPORT_EVENT = '/MediaRenderer/AVTransport/Event'
+const RENDERING_EVENT = '/MediaRenderer/RenderingControl/Event'
+
 /**
  * Dependencies
  */
@@ -1168,6 +1171,119 @@ Sonos.prototype.getQueue = function (callback) {
       }
       return callback(null, result)
     })
+  })
+}
+
+// Make Sonos an EventEmitter
+util.inherits(Sonos, EventEmitter)
+
+/**
+ * Create a socket and start listening for Events from Sonos
+ * @param  {Object}   options     As defined in https://github.com/bencevans/node-sonos/blob/master/lib/events/listener.js
+ * @param  {Function} callback (err) result - string
+ * */
+Sonos.prototype.startListening = function (options, callback) {
+  var self = this
+  debug('Sonos.startListening(%j,%j)', options, callback)
+  if (this.eventListener != null) {
+    callback('Already listening')
+    return
+  }
+  // Lets create a listener and start listening
+  self.eventListener = new Listener(self, options)
+  self.eventListener.listen(function (err) {
+    if (err) {
+      callback(err)
+      return
+    }
+
+    // Listen for events and parse them
+    self.eventListener.on('serviceEvent', function (endpoint, sid, data) {
+      debug('Sonos serviceEvent (%j,%j)', endpoint, sid)
+      switch (endpoint) {
+        case TRANSPORT_EVENT: // This events triggers on State and Track change
+          // Get and emit state on changes
+          self.getCurrentState(function (err2, state) {
+            if (err2) {
+              debug('Error loading state %j', err2)
+              return
+            }
+            if (state !== self.lastState) {
+              self.lastState = state
+              self.emit('StateChanged', state)
+              debug('Emit state changed to %j', state)
+            }
+          })
+
+          self.currentTrack(function (err2, track) {
+            if (err2) {
+              debug('Error loading track %j', err2)
+            }
+            // TODO Check if it is a different track like state
+            self.emit('TrackChanged', track)
+            debug('Current Track changed to %j', track)
+          })
+
+          // self.currentTrack()
+          break
+        case RENDERING_EVENT: // This event triggers on volume and mute change
+          self.getVolume(function (err2, volume) {
+            if (err2) {
+              debug('Error loading volume %j', err2)
+              return
+            }
+            if (self.lastVolume !== volume) {
+              self.lastVolume = volume
+              self.emit('VolumeChanged', volume)
+              debug('Emit volume changed to %j', volume)
+            }
+          })
+          self.getMuted(function (err2, muted) {
+            if (err2) {
+              debug('Error getting muted %j', err2)
+              return
+            }
+            if (self.isMuted !== muted) {
+              self.isMuted = muted
+              self.emit('Muted', muted)
+              debug('Emit muted to %j', muted)
+            }
+          })
+          break
+
+        default:
+          debug('Received unexpected event %s from %s', endpoint, self.host)
+          break
+      }
+    })
+
+    // Subscribe to transport events
+    self.eventListener.addService(TRANSPORT_EVENT, function (error, sid) {
+      if (error) {
+        // Now what??
+        return
+      }
+      debug('Subscribed for %j', TRANSPORT_EVENT)
+    })
+
+    // Subscribe to rendering events
+    self.eventListener.addService(RENDERING_EVENT, function (error, sid) {
+      if (error) {
+        // Now what??
+        return
+      }
+      debug('Subscribed for %j', RENDERING_EVENT)
+    })
+  })
+}
+
+Sonos.prototype.stopListening = function (callback) {
+  if (!this.eventListener) {
+    callback('Not listening')
+    return
+  }
+  this.eventListener.stop(success => {
+    callback(null, true)
   })
 }
 

--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -130,7 +130,29 @@ var Sonos = function Sonos (host, port, options) {
 
   this.options.spotify = this.options.spotify || {}
   this.options.spotify.region = this.options.spotify.region || SpotifyRegion.US
+
+  // Attach to newListener event
+  var self = this
+  var implicitListen = function (event, listener) {
+    if (event === 'newListener') return
+    self.removeListener('newListener', implicitListen)
+    if (!self.eventListener) {
+      self.startListening(null, function (err, success) {
+        if (err) {
+          debug('Error implicitly started listening %j', err)
+        }
+        if (success) {
+          debug('Started listening implicitly')
+        }
+      })
+    }
+  }
+  this.on('newListener', implicitListen)
+  // Maybe stop the eventListener once last listener is removed?
 }
+
+// Make Sonos an EventEmitter
+util.inherits(Sonos, EventEmitter)
 
 /**
  * UPnP HTTP Request
@@ -1174,8 +1196,13 @@ Sonos.prototype.getQueue = function (callback) {
   })
 }
 
-// Make Sonos an EventEmitter
-util.inherits(Sonos, EventEmitter)
+// ----------------------------- EventEmitter part
+
+// Some Constants
+const EVENT_TRAKCHANGED = 'TrackChanged'
+const EVENT_STATECHANGED = 'StateChanged'
+const EVENT_VOLUMECHANGED = 'VolumeChanged'
+const EVENT_MUTED = 'Muted'
 
 /**
  * Create a socket and start listening for Events from Sonos
@@ -1209,7 +1236,7 @@ Sonos.prototype.startListening = function (options, callback) {
             }
             if (state !== self.lastState) {
               self.lastState = state
-              self.emit('StateChanged', state)
+              self.emit(EVENT_STATECHANGED, state)
               debug('Emit state changed to %j', state)
             }
           })
@@ -1219,7 +1246,7 @@ Sonos.prototype.startListening = function (options, callback) {
               debug('Error loading track %j', err2)
             }
             // TODO Check if it is a different track like state
-            self.emit('TrackChanged', track)
+            self.emit(EVENT_TRAKCHANGED, track)
             debug('Current Track changed to %j', track)
           })
 
@@ -1233,7 +1260,7 @@ Sonos.prototype.startListening = function (options, callback) {
             }
             if (self.lastVolume !== volume) {
               self.lastVolume = volume
-              self.emit('VolumeChanged', volume)
+              self.emit(EVENT_VOLUMECHANGED, volume)
               debug('Emit volume changed to %j', volume)
             }
           })
@@ -1244,7 +1271,7 @@ Sonos.prototype.startListening = function (options, callback) {
             }
             if (self.isMuted !== muted) {
               self.isMuted = muted
-              self.emit('Muted', muted)
+              self.emit(EVENT_MUTED, muted)
               debug('Emit muted to %j', muted)
             }
           })
@@ -1273,6 +1300,7 @@ Sonos.prototype.startListening = function (options, callback) {
       }
       debug('Subscribed for %j', RENDERING_EVENT)
     })
+    callback(null, true)
   })
 }
 
@@ -1280,10 +1308,12 @@ Sonos.prototype.stopListening = function (callback) {
   if (!this.eventListener) {
     throw new Error('Not listening')
   }
-  this.eventListener.stop(success => {
-    callback(null, true)
+  this.eventListener.stop(function (err, success) {
+    callback(err, success)
   })
 }
+
+// ----------------------------- End EventEmitter part
 
 /**
  * Search "Class"


### PR DESCRIPTION
Should fix #194

This way everyone can use the some what difficult event listener.
You can call `startListening` on the `Sonos` device, it will create a `Listener` in the background and start emitting event like `TrackChanged`, `VolumeChanged`, `Muted` and `StateChanged`.
