### PR TITLE
Fix bug in AlarmClock.listAlarms()

### DIFF
--- a/lib/services/AlarmClock.js
+++ b/lib/services/AlarmClock.js
@@ -72,6 +72,11 @@ AlarmClock.prototype.ListAlarms = function (callback) {
     self._parseKey(data, 'CurrentAlarmList', (err, output) => {
       if (err) return callback(err)
       var alarms = output.Alarms.Alarm
+      if (alarms === undefined) {
+        alarms = []
+      } else if (!Array.isArray(alarms)) {
+        alarms = [alarms]
+      }
       // For easier reading
       // alarms.forEach(alarm => {
       //   delete alarm.ProgramMetaData

--- a/lib/services/Service.js
+++ b/lib/services/Service.js
@@ -94,7 +94,8 @@ Service.prototype._request = function (action, variables, callback) {
  * @return {void}
  */
 Service.prototype._parseKey = function (input, key, callback) {
-  debug('Service._parseKey(%j, %j, %j)', input, key, callback)
+  debug('Service._parseKey(%j, %j)', key, callback)
+  // debug('Service._parseKey(%j, %j, %j)', input, key, callback)
   if (!input || !key || !callback) {
     debug('_parseKey something not defined')
   }

--- a/lib/services/Service.js
+++ b/lib/services/Service.js
@@ -94,7 +94,7 @@ Service.prototype._request = function (action, variables, callback) {
  * @return {void}
  */
 Service.prototype._parseKey = function (input, key, callback) {
-  debug('Service._parseKey(%j, %j)', key, callback)
+  debug('Service._parseKey(%j, %j, %j)', input, key, callback)
   if (!input || !key || !callback) {
     debug('_parseKey something not defined')
   }
@@ -103,7 +103,7 @@ Service.prototype._parseKey = function (input, key, callback) {
     return callback(new Error('Key doesn\'t exists'))
   }
 
-  parseString(input[key], {mergeAttrs: true, explicitArray: true}, (err, result) => {
+  parseString(input[key], {mergeAttrs: true, explicitArray: false}, (err, result) => {
     if (err) return callback(err)
     return callback(null, result)
   })

--- a/lib/services/Service.js
+++ b/lib/services/Service.js
@@ -103,7 +103,7 @@ Service.prototype._parseKey = function (input, key, callback) {
     return callback(new Error('Key doesn\'t exists'))
   }
 
-  parseString(input[key], {mergeAttrs: true, explicitArray: false}, (err, result) => {
+  parseString(input[key], {mergeAttrs: true, explicitArray: true}, (err, result) => {
     if (err) return callback(err)
     return callback(null, result)
   })


### PR DESCRIPTION
Fix for #211, where the return of `AlarmClock.ListAlarms()` is wrong.

Not sure what will be impacted by this change.  Alternatively, we could pass an optional parameter to `Service._parseKey()` for `explicitArray`, so each caller has their own say in this.