### PR TITLE
Exclude non-essential files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,0 @@
-examples
-docs

--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
     "type": "git",
     "url": "https://github.com/bencevans/node-sonos.git"
   },
+  "files": [
+    "index.js",
+    "lib"
+  ],
   "keywords": [
     "sonos",
     "music",


### PR DESCRIPTION
Switched from using `.npmignore` to the [`files`](https://docs.npmjs.com/files/package.json#files) array in package.json. This results in fewer lines, one less file and we don't need to keep track of which files to exclude.
  