### PR TITLE
Data from listener is used

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -5,7 +5,7 @@
  * @requires 'xml2js
  */
 
-const debug = require('debug')('sonos')
+const debug = require('debug')('sonos:helpers')
 const parseString = require('xml2js').parseString
 
 /**

--- a/lib/services/Service.js
+++ b/lib/services/Service.js
@@ -10,7 +10,7 @@
 
 const request = require('request-promise-native')
 const parseString = require('xml2js').parseString
-const debug = require('debug')('sonos-service')
+const debug = require('debug')('sonos:service')
 const Helpers = require('../helpers')
 
 /**

--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -17,7 +17,7 @@ const DEVICE_ENDPOINT = '/DeviceProperties/Control'
 const util = require('util')
 const EventEmitter = require('events').EventEmitter
 const request = require('request-promise-native')
-const debug = require('debug')('sonos')
+const debug = require('debug')('sonos:main')
 const Listener = require('./events/adv-listener')
 const Helpers = require('./helpers')
 
@@ -653,7 +653,9 @@ Sonos.prototype.playNotification = async function (options) {
   return new Promise(async (resolve, reject) => {
     debug('sonos.playNotification(%j)', options)
     const state = await this.getCurrentState()
+    debug('Current state %j', state)
     const wasPlaying = (state === 'playing' || state === 'transitioning')
+    debug('Was playing %j', wasPlaying)
     const wasListening = Listener.isListening()
     let volume = 0
     if (typeof options === 'object') {

--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -165,6 +165,7 @@ Sonos.prototype.currentTrack = async function () {
  */
 Sonos.prototype.getVolume = async function () {
   debug('Sonos.getVolume()')
+  if (this._isSubscribed && this._volume) return this._volume
   return this.renderingControlService().GetVolume()
 }
 
@@ -174,6 +175,7 @@ Sonos.prototype.getVolume = async function () {
  */
 Sonos.prototype.getMuted = async function () {
   debug('Sonos.getMuted()')
+  if (this._isSubscribed && this._mute) return this._mute
   return this.renderingControlService().GetMute()
 }
 
@@ -561,6 +563,7 @@ Sonos.prototype.getTopology = async function () {
  */
 Sonos.prototype.getCurrentState = function () {
   debug('Sonos.currentState()')
+  if (this._isSubscribed && this._state) return this._state
   return this.avTransportService().GetTransportInfo()
     .then(result => {
       return Helpers.TranslateState(result.CurrentTransportState)


### PR DESCRIPTION
It makes no sense to me to request the current state if the state from the listener (that is saved anyway) is also available.

This means that the library will respond more quickly it the listener is already listening for events for this speaker. We already got the state so that is send back to the user.