### PR TITLE
Force zones to be an array

### DIFF
--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -554,6 +554,9 @@ Sonos.prototype.getTopology = async function () {
         let zones, mediaServers
 
         zones = info.ZonePlayers.ZonePlayer
+        if(!Array.isArray(zones)) {
+          zones = [zones];
+        }
 
         zones.forEach(zone => {
           zone.name = zone['_']


### PR DESCRIPTION
Should fix #274, but only tested it with a single device on the network, as the XML-to-object conversion then causes the Zones property to be a single object instead of an array of zones as is expected on the next line.