### PR TITLE
Add support for TuneIn radio track titles

### DIFF
--- a/lib/events/eventParser.js
+++ b/lib/events/eventParser.js
@@ -32,11 +32,11 @@ EventParser._parseAvTransportEvent = async function (body, device) {
   if (eventData.CurrentTrackMetaData) {
     let currMeta = await Helpers.ParseXml(eventData.CurrentTrackMetaData)
     let track = Helpers.ParseDIDL(currMeta, device.host, device.port, eventData.CurrentTrackURI)
+    track.duration = Helpers.TimeToSeconds(eventData.CurrentTrackDuration)
+    track.queuePosition = parseInt(eventData.CurrentTrack)
 
-    if (!device._track || device._track.uri !== track.uri) {
-      device.emit('CurrentTrack', track)
-      device._track = track
-    }
+    device.emit('CurrentTrack', track)
+    device._track = track
     eventData.CurrentTrackMetaDataParsed = track
   }
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -140,7 +140,7 @@ Helpers.ParseDIDL = function (didl, host, port, trackUri) {
 
 Helpers.ParseDIDLItem = function (item, host, port, trackUri) {
   let track = {
-    title: item['dc:title'] || null,
+    title: item['r:streamContent'] || item['dc:title'] || null,
     artist: item['dc:creator'] || null,
     album: item['upnp:album'] || null,
     albumArtURI: item['upnp:albumArtURI'] || null


### PR DESCRIPTION
The title of the current track in a radio station is given in the <r:streamContent>-tag which is empty for Spotify playlists.

```xml
<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">
  <item id="-1" parentID="-1" restricted="true">
    <res protocolInfo="aac:*:application/octet-stream:*">aac://http://fm02-icecast.mtg-r.net/fm02_aac</res>
    <r:streamContent>Tom Petty - Learning To Fly</r:streamContent>
    <dc:title>fm02_aac</dc:title>
    <upnp:class>object.item</upnp:class>
  </item>
</DIDL-Lite>
```