### PR TITLE
Handle when albumArtURI is an Array

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -139,11 +139,15 @@ Helpers.ParseDIDL = function (didl, host, port, trackUri) {
 }
 
 Helpers.ParseDIDLItem = function (item, host, port, trackUri) {
+  let albumArtURI = item['upnp:albumArtURI'] || null
+  if (albumArtURI && Array.isArray(albumArtURI)) {
+    albumArtURI = albumArtURI.length > 0 ? albumArtURI[0] : null
+  }
   let track = {
     title: item['r:streamContent'] || item['dc:title'] || null,
     artist: item['dc:creator'] || null,
     album: item['upnp:album'] || null,
-    albumArtURI: item['upnp:albumArtURI'] || null
+    albumArtURI
   }
   if (trackUri) track.uri = trackUri
   if (host && port && track.albumArtURI && !track.albumArtURI.startsWith('http://')) {


### PR DESCRIPTION
If the `albumArtURI` of an item is an `Array`, the first item is picked

With a custom playlist I experienced that the `albumArtURI` could contain multiple paths to album art. That would lead to an error since the `startsWith` function is not defined for an `Array`.

This small change fixes that issue.

Let me know if you need more info on the bug.