### PR TITLE
fixed TuneIn support

### DIFF
--- a/examples/playTuneinRadio.js
+++ b/examples/playTuneinRadio.js
@@ -4,7 +4,7 @@ const sonos = new Sonos(process.env.SONOS_HOST || '192.168.2.11')
 // This example demonstrates playing radio staions
 // the Sonos built-in support for tunein radio.
 
-const stationId = '34682'
+const stationId = 's34682'
 const stationTitle = '88.5 | Jazz24 (Jazz)'
 
 sonos.playTuneinRadio(stationId, stationTitle).then(success => {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -54,9 +54,9 @@ Helpers.GenerateMetadata = function (uri, title = '', region = '3079') {
     var radioTitle = title || 'TuneIn Radio'
     if (parts[0] === 'radio') {
       return {
-        uri: 'x-sonosapi-stream:s' + parts[1] + '?sid=254&flags=8224&sn=0',
-        metadata: meta.replace('##SPOTIFYURI##', 'F00092020s' + parts[1])
-          .replace('##RESOURCETITLE##', radioTitle)
+        uri: 'x-sonosapi-stream:' + parts[1] + '?sid=254&flags=8224&sn=0',
+        metadata: meta.replace('##SPOTIFYURI##', 'F00092020' + parts[1])
+          .replace('##RESOURCETITLE##', Helpers.EncodeXml(radioTitle))
           .replace('##SPOTIFYTYPE##', 'object.item.audioItem.audioBroadcast')
           .replace('##PARENTID##', 'parentID="L" ')
           .replace('##REGION##', 'SA_RINCON65031_')


### PR DESCRIPTION
fixed using the proper uri (e.g. getFavourites returns uris already starting with 's')...
encoded the title, since TuneIn does not like unescaped ampersands...