### PR TITLE
Don't fail if ZPSupportInfo is empty

### DIFF
--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -558,6 +558,12 @@ Sonos.prototype.getTopology = async function () {
       .then(result => {
         debug('getTopologyResult %j', result)
         const info = result.ZPSupportInfo
+        
+        if (!info) {
+          resolve({ zones: [], mediaServers: [] })
+          return
+        }
+
         let zones, mediaServers
 
         zones = info.ZonePlayers.ZonePlayer

--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -558,7 +558,7 @@ Sonos.prototype.getTopology = async function () {
       .then(result => {
         debug('getTopologyResult %j', result)
         const info = result.ZPSupportInfo
-        
+
         if (!info) {
           resolve({ zones: [], mediaServers: [] })
           return


### PR DESCRIPTION
Apparently ZPSupportInfo can sometimes just be an empty string, in which case there are no zones or media servers to find.