### PR TITLE
Fix bug in eventParser when constructing data for ZoneGroupTopology event

### DIFF
--- a/lib/events/eventParser.js
+++ b/lib/events/eventParser.js
@@ -119,7 +119,7 @@ EventParser._parseZoneGroupTopologyEvent = async function (body, device) {
       eventData[firstKey] = element[firstKey]
     }
   }
-  if (eventData.ZoneGroupState) {    
+  if (eventData.ZoneGroupState) {
     const zoneGroup = eventData.ZoneGroupState.ZoneGroups.ZoneGroup
     if (Array.isArray(zoneGroup)) {
       eventData.Zones = zoneGroup.map(zone => { return new SonosGroup(zone) })

--- a/lib/events/eventParser.js
+++ b/lib/events/eventParser.js
@@ -124,7 +124,7 @@ EventParser._parseZoneGroupTopologyEvent = async function (body, device) {
     if (Array.isArray(zoneGroup)) {
       eventData.Zones = zoneGroup.map(zone => { return new SonosGroup(zone) })
     } else {
-      eventData.Zones = new SonosGroup(zoneGroup)
+      eventData.Zones = [new SonosGroup(zoneGroup)]
     }
   }
   return { name: 'ZoneGroupTopology', eventBody: eventData }


### PR DESCRIPTION
This fixes a bug that would cause the ZoneGroupTopology event to not be emitted because map was being called on an object when an array was expected.

This error consistently popped up when I grouped all my Sonos speakers together into one group. ZoneGroup was an object in this case and would throw an error.

Error:
```bash
(node:30873) UnhandledPromiseRejectionWarning: TypeError: eventData.ZoneGroupState.ZoneGroups.ZoneGroup.map is not a function
    at Object.EventParser._parseZoneGroupTopologyEvent (/Users/nicholasvillarreal/Developer/ByteGenesis/sonos-web/server/node_modules/sonos/lib/events/eventParser.js:124:69)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
(node:30873) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:30873) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```