### PR TITLE
feat: extend search for playlist tracks

### DIFF
--- a/examples/getsonosplaylists.js
+++ b/examples/getsonosplaylists.js
@@ -4,3 +4,7 @@ const sonos = new Sonos(process.env.SONOS_HOST || '192.168.2.11')
 sonos.getMusicLibrary('sonos_playlists', { start: 0, total: 25 }).then(playlists => {
   console.log('Got current playlists %j', playlists)
 }).catch(err => { console.log('Error occurred %j', err) })
+
+sonos.getPlaylist('1', { start: 0, total: 25 }).then(results => {
+  console.log('Got current playlist items %j', results)
+}).catch(err => { console.log('Error occurred %j', err) })

--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -104,8 +104,8 @@ Sonos.prototype.searchMusicLibrary = async function (searchType, searchTerm, req
     'composers': 'A:COMPOSER',
     'tracks': 'A:TRACKS',
     'playlists': 'A:PLAYLISTS',
-    'sonos_playlists': 'SQ:',
-    'share': 'S:'
+    'sonos_playlists': 'SQ',
+    'share': 'S'
   }
   var defaultOptions = {
     BrowseFlag: 'BrowseDirectChildren',
@@ -114,10 +114,10 @@ Sonos.prototype.searchMusicLibrary = async function (searchType, searchTerm, req
     RequestedCount: '100',
     SortCriteria: ''
   }
-  let searches = searchTypes[searchType]
+  let searches = `${searchTypes[searchType]}${separator}`
 
   if (searchTerm && searchTerm !== '') {
-    searches = searches.concat(separator + encodeURIComponent(searchTerm))
+    searches = searches.concat(encodeURIComponent(searchTerm))
   }
 
   var opts = {
@@ -126,8 +126,18 @@ Sonos.prototype.searchMusicLibrary = async function (searchType, searchTerm, req
   if (requestOptions && requestOptions.start !== undefined) opts.StartingIndex = requestOptions.start
   if (requestOptions && requestOptions.total !== undefined) opts.RequestedCount = requestOptions.total
   // opts = _.extend(defaultOptions, opts)
-  Object.assign(opts, defaultOptions)
+  opts = Object.assign({}, defaultOptions, opts)
   return this.contentDirectoryService().GetResult(opts)
+}
+
+/**
+ * Get Sonos Playlist
+ * @param {String}    playlistId      Sonos id of the playlist
+ * @param  {Object}   requestOptions  Optional - default {start: 0, total: 100}
+ * @returns {Object} {returned: {String}, total: {String}, items:[{title:{String}, uri: {String}}]}
+ */
+Sonos.prototype.getPlaylist = async function (playlistId, requestOptions = {}) {
+  return this.searchMusicLibrary('sonos_playlists', playlistId, requestOptions)
 }
 
 /**

--- a/test/sonos.test.js
+++ b/test/sonos.test.js
@@ -400,6 +400,12 @@ describe('SonosDevice', function () {
     })
   })
 
+  it('should getPlaylist()', function () {
+    return sonos.getPlaylist('1').then(function (playlist) {
+      assert(playlist.items, 'should have items')
+    })
+  })
+
   it('should getQueue()', function () {
     return sonos.getQueue().then(function (queue) {
       assert(queue.items, 'should have items')


### PR DESCRIPTION
Hi everyone,

I added the feature to be able to access the items of a playlist. For this I had to do a small refactoring of the `searchMusicLibrary`. 
I also encountered a problem for setting additional `requestOptions`. Fixed this also within the same changes.