### PR TITLE
expose items id and parentID

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -211,12 +211,25 @@ Helpers.ParseDIDL = function (didl, host, port, trackUri) {
   return Helpers.ParseDIDLItem(item, host, port, trackUri)
 }
 
+Helpers.dropIDNamespace = function (value) {
+  if (!value) {
+    return null
+  }
+  let ret = value.split(':', 2)[1]
+  if (ret.length === 0) {
+    return null
+  }
+  return ret
+}
+
 Helpers.ParseDIDLItem = function (item, host, port, trackUri) {
   let albumArtURI = item['upnp:albumArtURI'] || null
   if (albumArtURI && Array.isArray(albumArtURI)) {
     albumArtURI = albumArtURI.length > 0 ? albumArtURI[0] : null
   }
   let track = {
+    id: Helpers.dropIDNamespace(item.id),
+    parentID: Helpers.dropIDNamespace(item.parentID),
     title: item['r:streamContent'] || item['dc:title'] || null,
     artist: item['dc:creator'] || null,
     album: item['upnp:album'] || null,

--- a/test/sonos.test.js
+++ b/test/sonos.test.js
@@ -540,6 +540,18 @@ describe('SonosDevice', function () {
     })
   })
 
+  it('should getMusicLibrary("sonos_playlists")', function () {
+    return sonos.getMusicLibrary('sonos_playlists').then(function (playlists) {
+      assert(playlists.items, 'should have items')
+      if (playlists.items.length > 0) {
+        assert('id' in playlists.items[0], 'item should have id in object')
+        assert('parentID' in playlists.items[0], 'item should have parentID in object')
+        assert('uri' in playlists.items[0], 'item should have uri in object')
+        assert('title' in playlists.items[0], 'item should have title in object')
+      }
+    })
+  })
+
   it('should getPlaylist()', function () {
     return sonos.getPlaylist('1').then(function (playlist) {
       assert(playlist.items, 'should have items')


### PR DESCRIPTION
This helps to manage Playlists as you can get real id of playlist.
Added unit test with sonos_playlists lookup