### PR TITLE
Fix issue when groups is not an array

### DIFF
--- a/lib/services/ZoneGroupTopology.js
+++ b/lib/services/ZoneGroupTopology.js
@@ -48,6 +48,9 @@ ZoneGroupTopology.prototype.AllZoneGroups = async function () {
       zoneGroupState = zoneGroupState.ZoneGroupState
     }
     let groups = zoneGroupState.ZoneGroups.ZoneGroup
+    if (!Array.isArray(groups)) {
+      groups = [groups]
+    }
     for (let i = 0; i < groups.length; i++) {
       if (!Array.isArray(groups[i].ZoneGroupMember)) {
         groups[i].ZoneGroupMember = [groups[i].ZoneGroupMember]


### PR DESCRIPTION
`zoneGroupState.ZoneGroups.ZoneGroup` is not always an array, which lead to `ZoneGroup.ZoneGroupMember` also not being an array.

This fixes an issue where `sonos-cli` list commands fail with `TypeError: zone.ZoneGroupMember.find is not a function`

I'm not sure if this issue should be fixed here or in `sonos-cli` though.