### PR TITLE
Error in documentation

### DIFF
--- a/examples/playTuneinRadio.js
+++ b/examples/playTuneinRadio.js
@@ -4,7 +4,8 @@ const sonos = new Sonos(process.env.SONOS_HOST || '192.168.2.11')
 // This example demonstrates playing radio staions
 // the Sonos built-in support for tunein radio.
 
-const stationId = 's34682'
+// CAUTION: ID is without leading s
+const stationId = '34682'
 const stationTitle = '88.5 | Jazz24 (Jazz)'
 
 sonos.playTuneinRadio(stationId, stationTitle).then(success => {


### PR DESCRIPTION
Original documentation says that the radio ID for method "playTuneinRadio" has a leading "s". 
But the method only works without leading "s". 

I suggest modifying the documentation. 
