### PR TITLE
correction of previous modification

### DIFF
--- a/examples/playTuneinRadio.js
+++ b/examples/playTuneinRadio.js
@@ -4,8 +4,8 @@ const sonos = new Sonos(process.env.SONOS_HOST || '192.168.2.11')
 // This example demonstrates playing radio staions
 // the Sonos built-in support for tunein radio.
 
-// CAUTION: ID is without leading s
-const stationId = '34682'
+// CAUTION: in older release of node-red the stationId maybe without leading s 
+const stationId = 's34682'
 const stationTitle = '88.5 | Jazz24 (Jazz)'
 
 sonos.playTuneinRadio(stationId, stationTitle).then(success => {


### PR DESCRIPTION
I am now on the newest release of node-sonos and there the Id includes a leading "s". 
My previous "modification" accidentally was based on an old version, distributed with node-red-contrib-better-sonos. In that release the Id works without leading "s". 

Sorry for the inconvenience. 