### PR TITLE
Fix #450: searchMusicLibrary with ":" or "/" characters in the album …

### DIFF
--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -118,7 +118,7 @@ Sonos.prototype.searchMusicLibrary = async function (searchType, searchTerm, req
   let searches = `${searchTypes[searchType]}${separator}`
 
   if (searchTerm && searchTerm !== '') {
-    searches = searches.concat(encodeURI(searchTerm))
+    searches = searches.concat(encodeURIComponent(searchTerm))
   }
 
   var opts = {


### PR DESCRIPTION
…name does not yield results