### PR TITLE
Fixing Bass and Treble setters in RenderingControl

### DIFF
--- a/lib/services/RenderingControl.js
+++ b/lib/services/RenderingControl.js
@@ -111,13 +111,13 @@ class RenderingControl extends Service {
   }
 
   /**
-   * (Un)set bass of a speaker.
-   * @param {boolean} loudness Should it be with or without bass?
+   * Set bass of a speaker.
+   * @param {integer} bass desired level of bass, range from -10 to +10
    */
   async SetBass (bass) {
     return this._request('SetBass', {
       InstanceID: 0,
-      DesiredBass: (bass ? '1' : '0')
+      DesiredBass: bass
     })
   }
 
@@ -131,13 +131,13 @@ class RenderingControl extends Service {
   }
 
   /**
-   * (Un)set treble of a speaker.
-   * @param {boolean} treble Should it be with or without treble?
+   * Set treble of a speaker.
+   * @param {integer} treble desired level of treble, range from -10 to +10
    */
   async SetTreble (treble) {
     return this._request('SetTreble', {
       InstanceID: 0,
-      DesiredTreble: (treble ? '1' : '0')
+      DesiredTreble: treble
     })
   }
 
@@ -153,7 +153,7 @@ class RenderingControl extends Service {
 
   /**
    * (Un)set room calibration status (TruePlay) of a speaker.
-   * @param {boolean} enabled Should it be with or without treble?
+   * @param {boolean} enabled Should it be with or without truePlay?
    */
   async SetRoomCalibrationStatus (enabled) {
     return this._request('SetRoomCalibrationStatus', {


### PR DESCRIPTION
- Bass and treble just take value instead of forcing boolean
- Additional comments to explain values