### PR TITLE
Add missing import

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ From the repo, living on the edge
 ### Discovering Devices
 
 ```js
-const { DeviceDiscovery } = require('sonos')
+const { Sonos, DeviceDiscovery } = require('sonos')
 
 // event on all found...
 DeviceDiscovery((device) => {


### PR DESCRIPTION
If the import is missing, the following error is thrown:

```
sonos = new Sonos(device.host)
  ^

ReferenceError: Sonos is not defined
```

This PR should resolve this. Cheers.