### PR TITLE
Enhance metadata from original sources if possible

### DIFF
--- a/lib/services/AVTransport.js
+++ b/lib/services/AVTransport.js
@@ -197,13 +197,15 @@ class AVTransport extends Service {
           const track = Helpers.ParseDIDL(metadata)
           track.position = position
           track.duration = duration
+          if (trackUri) track.uri = trackUri
+          if (process.env.ENHANCE_METADATA) {
+            const mediaInfo = await this.GetMediaInfo()
+            await enhanceMetadata(track, metadata, mediaInfo);
+          }
           track.albumArtURL = !track.albumArtURI ? null
             : track.albumArtURI.startsWith('http') ? track.albumArtURI
               : 'http://' + this.host + ':' + this.port + track.albumArtURI
-          if (trackUri) track.uri = trackUri
           track.queuePosition = queuePosition
-          const mediaInfo = await this.GetMediaInfo()
-          await enhanceMetadata(track, metadata, mediaInfo, this.host, this.port);
           return track
         } else { // No metadata.
           return { position: position, duration: duration, queuePosition: queuePosition, uri: trackUri }

--- a/lib/services/AVTransport.js
+++ b/lib/services/AVTransport.js
@@ -6,6 +6,7 @@
 
 const Service = require('./Service')
 const Helpers = require('../helpers')
+const enhanceMetadata = require('./EnhanceMetadata')
 
 /**
  * Create a new instance of AVTransport
@@ -201,6 +202,8 @@ class AVTransport extends Service {
               : 'http://' + this.host + ':' + this.port + track.albumArtURI
           if (trackUri) track.uri = trackUri
           track.queuePosition = queuePosition
+          const mediaInfo = await this.GetMediaInfo()
+          await enhanceMetadata(track, metadata, mediaInfo, this.host, this.port);
           return track
         } else { // No metadata.
           return { position: position, duration: duration, queuePosition: queuePosition, uri: trackUri }

--- a/lib/services/ContentDirectory.js
+++ b/lib/services/ContentDirectory.js
@@ -7,6 +7,7 @@
 
 const Service = require('./Service')
 const Helpers = require('../helpers')
+const enhanceMetadata = require('./EnhanceMetadata')
 
 /**
  * Create a new instance of ContentDirectory
@@ -46,12 +47,18 @@ class ContentDirectory extends Service {
   async GetResult (options) {
     return this.Browse(options)
       .then(this._parseResult)
-      .then(data => {
+      .then(async data => {
         let items = []
         if (data.Result['DIDL-Lite'].container) {
           items = this._enumItems(data.Result['DIDL-Lite'].container)
         } else {
           items = this._enumItems(data.Result['DIDL-Lite'].item)
+        }
+
+        if (process.env.ENHANCE_METADATA) {
+          for (const item of items) {
+            await enhanceMetadata(item)
+          }
         }
 
         return {

--- a/lib/services/EnhanceMetadata.js
+++ b/lib/services/EnhanceMetadata.js
@@ -1,0 +1,74 @@
+const axios = require('axios');
+const jsdom = require('jsdom');
+const Helpers = require('../helpers');
+
+
+/**
+ * Get a soundcloud client_id
+ * Stolen from https://github.com/3jackdaws/soundcloud-lib
+ */
+class SoundCloudClientId {
+  constructor() {
+    this.clientId = null
+  }
+
+  /**
+   * Get the id
+   * @returns {string} The client_id
+   */
+  async get() {
+    if (this.clientId) return this.clientId;
+
+    const dom = await jsdom.JSDOM.fromURL('https://soundcloud.com/mt-marcy/cold-nights')
+    const scripts = dom.window.document.querySelectorAll('script');
+
+    for (const script of scripts) {
+      const src = script.getAttribute('src')
+      if (src) {
+        const script_src = await axios({ url: src, method: 'GET' })
+        if (script_src.status === 200) {
+          const clientIds = script_src.data.match(/client_id=([a-zA-Z0-9]+)/)
+          if (clientIds && clientIds.length > 1) { 
+            this.clientId = clientIds[1];
+            break;
+          }
+        }
+      }
+    }
+    return this.clientId;
+  }
+}
+
+const soundCloudClientId = new SoundCloudClientId();
+
+
+/**
+ * Enhance metadata with data from original sources
+ *   * Add radio title and album art
+ *   * Add soundcloud album art
+ */
+module.exports = async function exhanceMetadata(track, metadata, mediaInfo, host, port) {
+  // Radio
+  if (mediaInfo.CurrentURI.startsWith('x-sonosapi-stream')) {
+    track.albumArtURL = `http://${host}:${port}/getaa?s=1&u=${encodeURIComponent(mediaInfo.CurrentURI)}`;
+    if (mediaInfo.CurrentURIMetaData) {
+      const miMetadata = await Helpers.ParseXml(mediaInfo.CurrentURIMetaData);
+      const parsedMediainfo = Helpers.ParseDIDL(miMetadata);
+
+      // For radio set artist = stream title
+      if (!track.artist) track.artist = parsedMediainfo.title
+    }
+  }
+
+  // Soundcloud
+  const uriParts = /x-sonos-http:track%3a(\d+)\.mp3\?sid=160/.exec(track.uri);
+  if (uriParts) {
+    const id = uriParts[1];
+    const clientId = process.env.SOUNDCLOUD_CLIENT_ID || await soundCloudClientId.get();
+    const apiUrl = `http://api-v2.soundcloud.com/tracks/${id}?client_id=${clientId}`;
+    const res = await axios({ url: apiUrl, method: 'GET' });
+    if (res.status === 200 && res.data && res.data.artwork_url) {
+      track.albumArtURL = res.data.artwork_url.replace('large', 't500x500');
+    }
+  }
+}

--- a/lib/services/EnhanceMetadata.js
+++ b/lib/services/EnhanceMetadata.js
@@ -47,10 +47,10 @@ const soundCloudClientId = new SoundCloudClientId();
  *   * Add radio title and album art
  *   * Add soundcloud album art
  */
-module.exports = async function exhanceMetadata(track, metadata, mediaInfo, host, port) {
+module.exports = async function enhanceMetadata(track, metadata, mediaInfo) {
   // Radio
-  if (mediaInfo.CurrentURI.startsWith('x-sonosapi-stream')) {
-    track.albumArtURL = `http://${host}:${port}/getaa?s=1&u=${encodeURIComponent(mediaInfo.CurrentURI)}`;
+  if (mediaInfo && mediaInfo.CurrentURI && mediaInfo.CurrentURI.startsWith('x-sonosapi-stream')) {
+    track.albumArtURI = `/getaa?s=1&u=${encodeURIComponent(mediaInfo.CurrentURI)}`;
     if (mediaInfo.CurrentURIMetaData) {
       const miMetadata = await Helpers.ParseXml(mediaInfo.CurrentURIMetaData);
       const parsedMediainfo = Helpers.ParseDIDL(miMetadata);
@@ -68,7 +68,7 @@ module.exports = async function exhanceMetadata(track, metadata, mediaInfo, host
     const apiUrl = `http://api-v2.soundcloud.com/tracks/${id}?client_id=${clientId}`;
     const res = await axios({ url: apiUrl, method: 'GET' });
     if (res.status === 200 && res.data && res.data.artwork_url) {
-      track.albumArtURL = res.data.artwork_url.replace('large', 't500x500');
+      track.albumArtURI = res.data.artwork_url.replace('large', 't500x500');
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "axios": "^0.19.0",
     "debug": "^4.1.1",
     "ip": "^1.1.5",
-    "xml2js": "^0.4.19"
+    "xml2js": "^0.4.19",
+    "jsdom": "^16.4.0"
   },
   "bugs": {
     "url": "http://github.com/bencevans/node-sonos/issues"


### PR DESCRIPTION
I've tried to isolate the interaction with other services. Enhanced metadata can be enabled by setting `ENHANCE_METADATA=true` in your env. Works for currently playing and things in the queue.

Some feedback on this would be useful, there are likely things i dont understand about how album art urls are generated, maybe there is a way to dynamically retrieve the radio url? 