### PR TITLE
fix: Ignore errors from missing albumArtURI

### DIFF
--- a/lib/services/AVTransport.js
+++ b/lib/services/AVTransport.js
@@ -196,10 +196,12 @@ class AVTransport extends Service {
           const track = Helpers.ParseDIDL(metadata)
           track.position = position
           track.duration = duration
-          track.albumArtURL = !track.albumArtURI ? null
-            : track.albumArtURI.startsWith('http') ? track.albumArtURI
-              : 'http://' + this.host + ':' + this.port + track.albumArtURI
-          if (trackUri) track.uri = trackUri
+          try { 
+		    track.albumArtURL = !track.albumArtURI ? null
+              : track.albumArtURI.startsWith('http') ? track.albumArtURI
+                : 'http://' + this.host + ':' + this.port + track.albumArtURI
+            if (trackUri) track.uri = trackUri
+          } catch(e) {}
           track.queuePosition = queuePosition
           return track
         } else { // No metadata.


### PR DESCRIPTION
Potential fix for #516 . My guess is sonos metadata changed? It might be better to understand the problem better, this just swallows the error so the rest of the function can operate.