### PR TITLE
Fix: Fixed documentation typo on code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ DeviceDiscovery((device) => {
 
   // mute every device...
   device.setMuted(true)
-    .then(d => console.log(`${d.host} now muted`))
+    .then(d => console.log(`${device.host} now muted`))
 })
 
 // find one device


### PR DESCRIPTION
On the first sample it says 'd.host' instead of 'device.host'